### PR TITLE
Dev

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,15 +1,14 @@
-use std::{ 
+use std::{
     env,
     net::{SocketAddr, UdpSocket},
-    sync::{Arc,Mutex},
     str::FromStr,
+    sync::{Arc, Mutex},
     thread,
-    time::{Duration, Instant}
+    time::{Duration, Instant},
 };
 
-
 #[derive(Clone, Debug)]
-struct PeerInfo{
+struct PeerInfo {
     addr: SocketAddr,
     last_pong: Instant,
     username: String,
@@ -20,9 +19,7 @@ fn main() -> std::io::Result<()> {
     //CLI arguments: signaling_ip, server, channel, user, local_port
     let args: Vec<String> = env::args().collect();
     if args.len() < 7 {
-        eprintln!(
-            "Usage: client <signaling_ip> <server_id> <channel> <user> <local_port>"
-        );
+        eprintln!("Usage: client <signaling_ip> <server_id> <channel> <user> <local_port>");
         std::process::exit(1);
     }
 
@@ -59,7 +56,7 @@ fn main() -> std::io::Result<()> {
         let signaling_addr = signaling_addr.to_string();
 
         thread::spawn(move || {
-            loop{
+            loop {
                 let hb = format!("HB {} {} {}", server_id, channel, user);
                 let _ = socket_clone.send_to(hb.as_bytes(), &signaling_addr);
                 thread::sleep(Duration::from_secs(20));
@@ -69,12 +66,12 @@ fn main() -> std::io::Result<()> {
 
     // 2. Aggregate server responses for a short window
     let setup_deadline = Instant::now() + Duration::from_millis(1500);
-    while Instant::now() < setup_deadline{
-        match socket.recv_from(&mut buf){
+    while Instant::now() < setup_deadline {
+        match socket.recv_from(&mut buf) {
             Ok((len, _)) => {
                 let resp = String::from_utf8_lossy(&buf[..len]).to_string();
                 println!("Server response:\n{}", resp);
-                for line in resp.lines(){
+                for line in resp.lines() {
                     handle_mode_line(line.trim(), &peers, user, &is_relay);
                 }
             }
@@ -94,24 +91,24 @@ fn main() -> std::io::Result<()> {
         let socket_clone = socket.try_clone()?;
         thread::spawn(move || {
             //We'll keep punching until peer.connected == true or timeout
-            let punch_start = Instant::now();
-            while punch_start.elapsed() < Duration::from_secs(5){
-                let guard = peers_clone.lock().unwrap();
-                for p in guard.iter(){
-                    if !p.connected{
-                        if let Err(e) = socket_clone.send_to(b"HOLE_PUNCH", p.addr){
-                            eprintln!("Failed to send punch to{}: {}", p.addr, e);
-                        }else{
-                            println!("Sent UDP punch to {} ({})", p.username, p.addr);
+            loop {
+                {
+                    let guard = peers_clone.lock().unwrap();
+                    for p in guard.iter() {
+                        if !p.connected {
+                            if let Err(e) = socket_clone.send_to(b"HOLE_PUNCH", p.addr) {
+                                eprintln!("Failed to send punch to{}: {}", p.addr, e);
+                            } else {
+                                println!("Sent UDP punch to {} ({})", p.username, p.addr);
+                            }
                         }
                     }
                 }
-                drop(guard);
                 thread::sleep(Duration::from_millis(500));
             }
+            // }
         });
     }
-
 
     // 3. Relay keepalive thread starter
     {
@@ -124,13 +121,13 @@ fn main() -> std::io::Result<()> {
         let server_id = server_id.to_string();
         let channel = channel.to_string();
         let signaling_addr = signaling_addr.to_string();
-        
+
         thread::spawn(move || {
-            loop{
-                if *is_relay_clone.lock().unwrap(){
+            loop {
+                if *is_relay_clone.lock().unwrap() {
                     let mut started = relay_started_clone.lock().unwrap();
                     //Only start one relay loop
-                    if *started{
+                    if *started {
                         thread::sleep(Duration::from_secs(1));
                         continue;
                     }
@@ -138,36 +135,44 @@ fn main() -> std::io::Result<()> {
                     drop(started);
                     println!("Starting relay keepalive thread");
 
-                    loop{
-                        thread::sleep(Duration::from_secs(20));
+                    loop {
                         let mut to_remove = Vec::new();
                         {
                             let mut guard = peers_clone.lock().unwrap();
-                            for(i, peer) in guard.iter_mut().enumerate(){
-                                if peer.last_pong.elapsed() > Duration::from_secs(60){
-                                    println!("Peer {} timeout - reporting to server", peer.username);
+                            for (i, peer) in guard.iter_mut().enumerate() {
+                                if peer.last_pong.elapsed() > Duration::from_secs(60) {
+                                    println!(
+                                        "Peer {} timeout - reporting to server",
+                                        peer.username
+                                    );
                                     let _ = socket_clone.send_to(
-                                        format!("PEER_TIMEOUT {} {} {}", server_id, channel, peer.username).as_bytes(),
+                                        format!(
+                                            "PEER_TIMEOUT {} {} {}",
+                                            server_id, channel, peer.username
+                                        )
+                                        .as_bytes(),
                                         &signaling_addr,
                                     );
                                     to_remove.push(i);
-                                }else{
-                                    if let Err(e) = socket_clone.send_to(b"PING", peer.addr){
+                                } else {
+                                    if let Err(e) = socket_clone.send_to(b"PING", peer.addr) {
                                         eprintln!("Failed to send PING to {}: {}", peer.addr, e);
                                     }
                                 }
                             }
 
-                            for &idx in to_remove.iter().rev(){
+                            for &idx in to_remove.iter().rev() {
                                 guard.remove(idx);
                             }
                         }
 
-                        if !*is_relay_clone.lock().unwrap(){
+                        if !*is_relay_clone.lock().unwrap() {
                             //we lost relay role
                             *relay_started_clone.lock().unwrap() = false;
                             break;
                         }
+
+                        thread::sleep(Duration::from_secs(15));
                     }
                 }
                 thread::sleep(Duration::from_millis(200));
@@ -176,14 +181,14 @@ fn main() -> std::io::Result<()> {
     }
 
     println!("Starting main message loop...");
-    loop{
-        match socket.recv_from(&mut buf){
+    loop {
+        match socket.recv_from(&mut buf) {
             Ok((len, src)) => {
                 let message = String::from_utf8_lossy(&buf[..len]).to_string();
                 //If message comes from a peer addr, mark them as connected
                 {
                     let mut guard = peers.lock().unwrap();
-                    if let Some(p) = guard.iter_mut().find(|p| p.addr == src){
+                    if let Some(p) = guard.iter_mut().find(|p| p.addr == src) {
                         p.last_pong = Instant::now();
                         p.connected = true;
                     }
@@ -191,39 +196,41 @@ fn main() -> std::io::Result<()> {
 
                 for line in message.lines() {
                     let line = line.trim();
-                    if line.is_empty() { continue; }
-                    match line{
+                    if line.is_empty() {
+                        continue;
+                    }
+                    match line {
                         "PING" => {
                             let _ = socket.send_to(b"PONG", src);
                             println!("Received PING from {}, sent PONG", src);
-                        },
+                        }
                         "PONG" => {
                             //update last_pong if this is a known peer
                             let mut peers_guard = peers.lock().unwrap();
-                            if let Some(peer) = peers_guard.iter_mut().find(|p| p.addr == src){
+                            if let Some(peer) = peers_guard.iter_mut().find(|p| p.addr == src) {
                                 peer.last_pong = Instant::now();
                                 println!("Received PONG from {}", peer.username);
                             }
-                        },
+                        }
                         "HOLE_PUNCH" => {
                             println!("Received hole punch from {}", src);
                             //mark peer connected
                             let mut peers_guard = peers.lock().unwrap();
-                            if let Some(peer) = peers_guard.iter_mut().find(|p| p.addr == src){
+                            if let Some(peer) = peers_guard.iter_mut().find(|p| p.addr == src) {
                                 peer.connected = true;
                                 peer.last_pong = Instant::now();
                             }
-                        },
+                        }
                         _ => {
                             //Handle control messages: MODE / USER_LEFT
                             handle_mode_line(line, &peers, user, &is_relay);
                         }
                     }
                 }
-            },
+            }
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 thread::sleep(Duration::from_millis(50));
-            },
+            }
             Err(e) => {
                 eprintln!("Error receiving: {}", e);
                 return Err(e);
@@ -232,31 +239,38 @@ fn main() -> std::io::Result<()> {
     }
 
     // unreachable
-   // Ok(())
+    // Ok(())
 }
 
-fn handle_mode_line(line: &str, peers: &Arc<Mutex<Vec<PeerInfo>>>, me: &str, is_relay: &Arc<Mutex<bool>>){
+fn handle_mode_line(
+    line: &str,
+    peers: &Arc<Mutex<Vec<PeerInfo>>>,
+    me: &str,
+    is_relay: &Arc<Mutex<bool>>,
+) {
     let parts: Vec<&str> = line.split_whitespace().collect();
-    if parts.is_empty(){ return; }
+    if parts.is_empty() {
+        return;
+    }
 
-    match parts[0]{
+    match parts[0] {
         "MODE" if parts.len() >= 2 && parts[1] == "RELAY" => {
             let mut r = is_relay.lock().unwrap();
             if !*r {
                 *r = true;
                 println!("You are in RELAY MODE");
             }
-        },
+        }
         "MODE" if parts.len() >= 2 && parts[1] == "SERVER_RELAY" => {
-              println!("Server is currently being relay for the lone user.");
-        },
+            println!("Server is currently being relay for the lone user.");
+        }
         "MODE" if parts.len() >= 4 && parts[1] == "DIRECT" => {
             let username = parts[2];
             let addr_str = parts[3];
-            if let Ok(addr) = SocketAddr::from_str(addr_str){
+            if let Ok(addr) = SocketAddr::from_str(addr_str) {
                 let mut guard = peers.lock().unwrap();
-                if username != me{
-                    if !guard.iter().any(|p| p.addr == addr){
+                if username != me {
+                    if !guard.iter().any(|p| p.addr == addr) {
                         guard.push(PeerInfo {
                             addr,
                             last_pong: Instant::now(),
@@ -265,17 +279,17 @@ fn handle_mode_line(line: &str, peers: &Arc<Mutex<Vec<PeerInfo>>>, me: &str, is_
                         });
                         println!("Added peer {} with addr {}", username, addr_str);
                     }
-                }else{
+                } else {
                     println!("Server confirms you ({}) are relay for {}", me, addr_str);
                 }
             }
-        },
+        }
         "USER_LEFT" if parts.len() >= 2 => {
             let username = parts[1];
             let mut guard = peers.lock().unwrap();
             guard.retain(|p| p.username != username.to_string());
-            println!("Peer {} left, removed from list", username);
-        },
+            println!("[CLIENT:user] {} left, removed from list", username);
+        }
         _ => {
             println!("Unhandled control line: {}", line);
         }

--- a/src/bin/signaling_server.rs
+++ b/src/bin/signaling_server.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     net::SocketAddr,
     sync::Arc,
-    time::{Duration, Instant}
+    time::{Duration, Instant},
 };
 use tokio::{net::UdpSocket, sync::Mutex};
 
@@ -14,7 +14,7 @@ struct User {
 }
 
 #[derive(Clone, Debug, Default)]
-struct Channel{
+struct Channel {
     users: Vec<User>,
     relay: Option<String>, //username of the relay
 }
@@ -33,57 +33,71 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start heartbeat task (collect addresses to ping while holding lock, then send without lock)
     let heartbeat_socket = Arc::clone(&socket);
     let heartbeat_state = Arc::clone(&state);
-    tokio::spawn(async move{
+    tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(20));
-        loop{
+        loop {
             interval.tick().await;
 
             //Collect:
             // -pings to send (server -> lone users to keep NAT)
             // - cleanup of empty channels
             // -per-timeout notifications to send after lock is release
-            let (to_ping, to_cleanup, notify_msgs): (Vec<SocketAddr>, Vec<(String, String)>, Vec<(Vec<SocketAddr>, Vec<u8>)>) ={
+            let (to_ping, to_cleanup, notify_msgs): (
+                Vec<SocketAddr>,
+                Vec<(String, String)>,
+                Vec<(Vec<SocketAddr>, Vec<u8>)>,
+            ) = {
                 let mut st = heartbeat_state.lock().await;
                 let mut pings = Vec::new();
                 let mut cleanup = Vec::new();
                 let mut notifications: Vec<(Vec<SocketAddr>, Vec<u8>)> = Vec::new();
 
                 let server_ids: Vec<String> = st.keys().cloned().collect();
-                for sid in server_ids.iter(){
-                    if let Some(channels) = st.get_mut(sid){
+                for sid in server_ids.iter() {
+                    if let Some(channels) = st.get_mut(sid) {
                         let channel_names: Vec<String> = channels.keys().cloned().collect();
-                        for cname in channel_names.iter(){
-                            if let Some(channel) = channels.get_mut(cname){
+                        for cname in channel_names.iter() {
+                            if let Some(channel) = channels.get_mut(cname) {
                                 //check users for timeouts (use last_pong for all users)
                                 let mut i = 0;
-                                while i < channel.users.len(){
+                                while i < channel.users.len() {
                                     let user = &channel.users[i];
 
                                     //if we've seen no HB/PONG for this user in the timeout window, he timed out
-                                    if user.last_pong.elapsed() > Duration::from_secs(40){
-                                        println!("User {} timed out from {}-{}", user.name, sid, cname);
+                                    if user.last_pong.elapsed() > Duration::from_secs(40) {
+                                        println!(
+                                            "User {} timed out from {}-{}",
+                                            user.name, sid, cname
+                                        );
 
                                         //prepare USER-LEFT notification to remaining users (collect their addresses now)
-                                        let msg = format!("USER_LEFT {} {}\n", user.name, user.addr);
-                                        let peers_to_notify: Vec<SocketAddr> = channel.users
+                                        let msg =
+                                            format!("USER_LEFT {} {}\n", user.name, user.addr);
+                                        let peers_to_notify: Vec<SocketAddr> = channel
+                                            .users
                                             .iter()
                                             .filter(|u| u.addr != user.addr) //remaining peers
                                             .map(|u| u.addr)
                                             .collect();
 
-                                        if !peers_to_notify.is_empty(){
-                                            notifications.push((peers_to_notify, msg.as_bytes().to_vec()));
+                                        if !peers_to_notify.is_empty() {
+                                            notifications
+                                                .push((peers_to_notify, msg.as_bytes().to_vec()));
                                         }
 
                                         //detect whether this user was relay
-                                        let was_relay = channel.relay.as_ref().map(|r| r == &user.name).unwrap_or(false);
+                                        let was_relay = channel
+                                            .relay
+                                            .as_ref()
+                                            .map(|r| r == &user.name)
+                                            .unwrap_or(false);
 
                                         //remove the user
                                         channel.users.remove(i);
 
                                         //if we removed the relay and there are still users, promote first
-                                        if was_relay{
-                                            if !channel.users.is_empty(){
+                                        if was_relay {
+                                            if !channel.users.is_empty() {
                                                 let new_relay = channel.users[0].name.clone();
                                                 channel.relay = Some(new_relay.clone());
 
@@ -91,41 +105,72 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                                 let new_relay_addr = channel.users[0].addr;
 
                                                 //notify new relay
-                                                notifications.push((vec![new_relay_addr], b"MODE RELAY\n".to_vec()));
+                                                notifications.push((
+                                                    vec![new_relay_addr],
+                                                    b"MODE RELAY\n".to_vec(),
+                                                ));
 
                                                 //notify other users about the new relay
                                                 let mut relinfo_msg = Vec::new();
-                                                for peer in channel.users.iter().skip(1){
-                                                    let m = format!("MODE DIRECT {} {}\n", new_relay, new_relay_addr);
+                                                for peer in channel.users.iter().skip(1) {
+                                                    let m = format!(
+                                                        "MODE DIRECT {} {}\n",
+                                                        new_relay, new_relay_addr
+                                                    );
                                                     relinfo_msg.extend_from_slice(m.as_bytes());
                                                 }
-                                                if !relinfo_msg.is_empty(){
-                                                    let others_addrs: Vec<SocketAddr> = channel.users.iter().skip(1).map(|u| u.addr).collect();
+                                                if !relinfo_msg.is_empty() {
+                                                    let others_addrs: Vec<SocketAddr> = channel
+                                                        .users
+                                                        .iter()
+                                                        .skip(1)
+                                                        .map(|u| u.addr)
+                                                        .collect();
                                                     notifications.push((others_addrs, relinfo_msg));
                                                 }
-                                            }else{
+
+                                                let mut peers_to_new_msg = Vec::new();
+                                                for peer in channel.users.iter().skip(1) {
+                                                    let m = format!(
+                                                        "MODE DIRECT {} {}\n",
+                                                        peer.name, peer.addr
+                                                    );
+                                                    peers_to_new_msg
+                                                        .extend_from_slice(m.as_bytes());
+                                                }
+
+                                                if !peers_to_new_msg.is_empty() {
+                                                    notifications.push((
+                                                        vec![new_relay_addr],
+                                                        peers_to_new_msg,
+                                                    ));
+                                                }
+                                            } else {
                                                 channel.relay = None;
                                             }
                                         }
 
                                         //if only one user left, ensure they are marked relay
-                                        if channel.users.len() == 1{
+                                        if channel.users.len() == 1 {
                                             channel.relay = Some(channel.users[0].name.clone());
                                             //notify lone user that they are relay (keepalive by server)
-                                            notifications.push((vec![channel.users[0].addr], b"MODE RELAY\n".to_vec()));
+                                            notifications.push((
+                                                vec![channel.users[0].addr],
+                                                b"MODE RELAY\n".to_vec(),
+                                            ));
                                         }
-                                    }else{
+                                    } else {
                                         i += 1;
-                                    }                         
-                                }//end per-user loop
+                                    }
+                                } //end per-user loop
 
                                 //if channel has only one user, ping him to keep NAT connection
-                                if channel.users.len() == 1{
+                                if channel.users.len() == 1 {
                                     pings.push(channel.users[0].addr);
                                 }
 
                                 //if channel empty, mark for cleanup
-                                if channel.users.is_empty(){
+                                if channel.users.is_empty() {
                                     cleanup.push((sid.clone(), cname.clone()));
                                 }
                             }
@@ -134,30 +179,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 (pings, cleanup, notifications)
             }; //lock dropped here
-            
+
             // Send pings without holding the lock
-            for addr in to_ping{
-                if let Err(e) = heartbeat_socket.send_to(b"PING", addr).await{
+            for addr in to_ping {
+                if let Err(e) = heartbeat_socket.send_to(b"PING", addr).await {
                     eprintln!("Failed to send PING: {}", e);
                 }
             }
 
             //send notifications (USER_LEFT, MODE RELAY, MODE DIRECT messages}
-            for (peers_to_notify, payload) in to_cleanup_and_notify_iter(notify_msgs.into_iter()){
-                for addr in peers_to_notify{
-                    if let Err(e) = heartbeat_socket.send_to(&payload, addr).await{
+            for (peers_to_notify, payload) in to_cleanup_and_notify_iter(notify_msgs.into_iter()) {
+                for addr in peers_to_notify {
+                    if let Err(e) = heartbeat_socket.send_to(&payload, addr).await {
                         eprintln!("Failed to send heartbeat notification to {}: {}", addr, e);
                     }
                 }
             }
 
             //Cleanup empty channels / servers
-            if !to_cleanup.is_empty(){
+            if !to_cleanup.is_empty() {
                 let mut st = heartbeat_state.lock().await;
-                for(sid, cname) in to_cleanup.into_iter(){
-                    if let Some(chans) = st.get_mut(&sid){
+                for (sid, cname) in to_cleanup.into_iter() {
+                    if let Some(chans) = st.get_mut(&sid) {
                         chans.remove(&cname);
-                        if chans.is_empty(){
+                        if chans.is_empty() {
                             st.remove(&sid);
                         }
                     }
@@ -172,11 +217,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let parts: Vec<&str> = msg.trim().split_whitespace().collect();
 
         // Handle PONG messages first (relay PING <-> client PONG)
-        if msg.trim() == "PONG"{
+        if msg.trim() == "PONG" {
             let mut st = state.lock().await;
-            for(_sid, channels) in st.iter_mut(){
-                for(_cname, channel) in channels.iter_mut(){
-                    if let Some(user) = channel.users.iter_mut().find(|u| u.addr == src){
+            for (_sid, channels) in st.iter_mut() {
+                for (_cname, channel) in channels.iter_mut() {
+                    if let Some(user) = channel.users.iter_mut().find(|u| u.addr == src) {
                         user.last_pong = Instant::now();
                     }
                 }
@@ -191,8 +236,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let channel_name = parts[2];
             let user_name = parts[3];
             let mut st = state.lock().await;
-            if let Some(channels) = st.get_mut(server_id){
-                if let Some(channel) = channels.get_mut(channel_name){
+            if let Some(channels) = st.get_mut(server_id) {
+                if let Some(channel) = channels.get_mut(channel_name) {
                     if let Some(u) = channel
                         .users
                         .iter_mut()
@@ -204,11 +249,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             continue;
         }
-        
+
         if parts.len() >= 1 {
             match parts[0] {
                 "CONNECT" if parts.len() >= 4 => {
-                    //CONNECT server_id channel_name user_name 
+                    //CONNECT server_id channel_name user_name
                     let server_id = parts[1].to_string();
                     let channel_name = parts[2].to_string();
                     let user_name = parts[3].to_string();
@@ -223,101 +268,129 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let channel = channels.entry(channel_name.clone()).or_default();
 
                         //check if user already present with same addr
-                        if let Some(existing) = channel.users.iter_mut().find(|u| u.name == user_name && u.addr == src_addr){
+                        if let Some(existing) = channel
+                            .users
+                            .iter_mut()
+                            .find(|u| u.name == user_name && u.addr == src_addr)
+                        {
                             existing.last_pong = Instant::now();
                             (channel.clone(), false)
-                        }else{
+                        } else {
                             //if name exists but with different addr, remove old one
-                            channel.users.retain(|u| !(u.name == user_name && u.addr != src_addr));
+                            channel
+                                .users
+                                .retain(|u| !(u.name == user_name && u.addr != src_addr));
 
-                            channel.users.push(User{
+                            channel.users.push(User {
                                 name: user_name.clone(),
                                 addr: src_addr,
-                                last_pong: Instant::now()
+                                last_pong: Instant::now(),
                             });
-                            
+
                             // promote user to relay if there's more than 1 user in the channel
-                            if channel.relay.is_none() && channel.users.len() == 1{
+                            if channel.relay.is_none() && channel.users.len() == 1 {
                                 //server maintains connection via ping
                                 let reply = "MODE SERVER_RELAY\n";
-                                if let Err(e) = socket.send_to(reply.as_bytes(), channel.users[0].addr).await{
-                                    eprintln!("Failed to notify lone user about server relay: {}", e);
+                                if let Err(e) = socket
+                                    .send_to(reply.as_bytes(), channel.users[0].addr)
+                                    .await
+                                {
+                                    eprintln!(
+                                        "Failed to notify lone user about server relay: {}",
+                                        e
+                                    );
                                 }
 
                                 //mark channel.relay to None (server is special relay)
                                 channel.relay = Some(channel.users[0].name.clone());
                             }
-                        
-                            println!("User {} joined {}-{} from {}", user_name, server_id, channel_name, src_addr);
+
+                            println!(
+                                "User {} joined {}-{} from {}",
+                                user_name, server_id, channel_name, src_addr
+                            );
                             (channel.clone(), true)
                         }
                     }; //lock dropped
-                                        
-                    if !is_new_user{
+
+                    if !is_new_user {
                         //nothing to notify
                         continue;
                     }
 
                     // Now decide messages to send based on cloned channel state
                     // if more than 1 user and relay wasn't set previously, promote first user
-                    if users_to_notify.users.len() > 1{
+                    if users_to_notify.users.len() > 1 {
                         //if there was a server marked relay (we earlier set relay name for lone users)
                         //we want the first client to become the real client relay
                         let relay_user = &users_to_notify.users[0];
-                    
+
                         //Mark relay in the channel
                         {
                             let mut st = state.lock().await;
-                            if let Some(channels) = st.get_mut(&server_id){
-                                if let Some(channel) = channels.get_mut(&channel_name){
+                            if let Some(channels) = st.get_mut(&server_id) {
+                                if let Some(channel) = channels.get_mut(&channel_name) {
                                     channel.relay = Some(relay_user.name.clone());
                                 }
                             }
                         }
-                        
+
                         //Notify the new relay about all other users (MODE DIRECT <peer> <addr>)
-                        for peer in users_to_notify.users.iter().skip(1){
+                        for peer in users_to_notify.users.iter().skip(1) {
                             let msg = format!("MODE DIRECT {} {}\n", peer.name, peer.addr);
-                            if let Err(e) = socket.send_to(msg.as_bytes(), relay_user.addr).await{
-                                eprintln!("Failed to notify relay {} about {}: {}", relay_user.name, peer.name, e);
+                            if let Err(e) = socket.send_to(msg.as_bytes(), relay_user.addr).await {
+                                eprintln!(
+                                    "Failed to notify relay {} about {}: {}",
+                                    relay_user.name, peer.name, e
+                                );
                             }
                         }
 
                         //Notify other users about the new relay (MODE DIRECT <relay> <addr>)
-                        for peer in users_to_notify.users.iter().skip(1){
-                            let msg = format!("MODE DIRECT {} {}\n", relay_user.name, relay_user.addr);
-                            if let Err(e) = socket.send_to(msg.as_bytes(), peer.addr).await{
-                                eprintln!("Failed to notify {} about new relay {}: {}", peer.name, relay_user.name, e);
+                        for peer in users_to_notify.users.iter().skip(1) {
+                            let msg =
+                                format!("MODE DIRECT {} {}\n", relay_user.name, relay_user.addr);
+                            if let Err(e) = socket.send_to(msg.as_bytes(), peer.addr).await {
+                                eprintln!(
+                                    "Failed to notify {} about new relay {}: {}",
+                                    peer.name, relay_user.name, e
+                                );
                             }
                         }
-                        
+
                         //Finally notify the relay itself that it shoult act as relay
                         let reply = "MODE RELAY\n";
-                        if let Err(e) = socket.send_to(reply.as_bytes(), relay_user.addr).await{
+                        if let Err(e) = socket.send_to(reply.as_bytes(), relay_user.addr).await {
                             eprintln!("Failed to send RELAY mode to {}: {}", relay_user.name, e);
                         }
                     } else {
                         //either theres only 1 user to notify, that we already handled
-                        //or the relay was already set, in which case 
+                        //or the relay was already set, in which case
                         //notify existing users about the new one, and the new one about existing users
-                        for user in users_to_notify.users.iter(){
-                            if user.addr != src_addr{
+                        for user in users_to_notify.users.iter() {
+                            if user.addr != src_addr {
                                 //notify existing user about the new one
-                                let msg_to_existing = format!("MODE DIRECT {} {}\n", user_name, src_addr);
-                                if let Err(e) = socket.send_to(msg_to_existing.as_bytes(), user.addr).await{
+                                let msg_to_existing =
+                                    format!("MODE DIRECT {} {}\n", user_name, src_addr);
+                                if let Err(e) =
+                                    socket.send_to(msg_to_existing.as_bytes(), user.addr).await
+                                {
                                     eprintln!("Failed to notify {}: {}", user.name, e);
                                 }
 
                                 //notify new user about the existing user
-                                let msg_to_new = format!("MODE DIRECT {} {}\n", user.name, user.addr);
-                                if let Err(e) = socket.send_to(msg_to_new.as_bytes(), src_addr).await{
+                                let msg_to_new =
+                                    format!("MODE DIRECT {} {}\n", user.name, user.addr);
+                                if let Err(e) =
+                                    socket.send_to(msg_to_new.as_bytes(), src_addr).await
+                                {
                                     eprintln!("Failed to notify new user: {}", e);
                                 }
                             }
                         }
                     }
                 }
-                            
+
                 "DISCONNECT" if parts.len() >= 4 => {
                     //DISCONNECT server_id channel_name user_name
                     let server_id = parts[1].to_string();
@@ -332,23 +405,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let mut leaving_user_addr = None;
                         let mut lone_user_addr = None;
 
-                        if let Some(channels) = st.get_mut(&server_id){
-                            if let Some(channel) = channels.get_mut(&channel_name){
+                        if let Some(channels) = st.get_mut(&server_id) {
+                            if let Some(channel) = channels.get_mut(&channel_name) {
                                 //find index of user with matching name and addr
-                                if let Some(pos) = channel.users.iter().position(|u| u.name == user_name && u.addr == src_addr){
+                                if let Some(pos) = channel
+                                    .users
+                                    .iter()
+                                    .position(|u| u.name == user_name && u.addr == src_addr)
+                                {
                                     //check if leaving user was relay
-                                    was_relay = channel.relay.as_ref().map(|r| r == &user_name).unwrap_or(false);
+                                    was_relay = channel
+                                        .relay
+                                        .as_ref()
+                                        .map(|r| r == &user_name)
+                                        .unwrap_or(false);
                                     leaving_user_addr = Some(channel.users[pos].addr);
                                     channel.users.remove(pos);
 
                                     //update relay if needed
-                                    if was_relay{
-                                        if !channel.users.is_empty(){
+                                    if was_relay {
+                                        if !channel.users.is_empty() {
                                             //set first user in list as relay
                                             let new_relay = channel.users[0].name.clone();
                                             channel.relay = Some(new_relay);
-                                        }else{
-                                             channel.relay = None;
+                                        } else {
+                                            channel.relay = None;
                                         }
                                     }
 
@@ -358,50 +439,84 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         lone_user_addr = Some(channel.users[0].addr);
                                     }
 
-                                    println!("User {} left {}-{}", user_name, server_id, channel_name);
-                                }else{
+                                    println!(
+                                        "User {} left {}-{}",
+                                        user_name, server_id, channel_name
+                                    );
+                                } else {
                                     //unknown session, so ignore
-                                    println!("Ignoring DISCONNECT for {} from {} (no matching session)", user_name, src_addr);                               
+                                    println!(
+                                        "Ignoring DISCONNECT for {} from {} (no matching session)",
+                                        user_name, src_addr
+                                    );
                                 }
                             }
                         }
-                    
+
                         let remaining_users = st
                             .get(&server_id)
                             .and_then(|channels| channels.get(&channel_name))
                             .map(|channel| channel.clone())
                             .unwrap_or_default();
 
-                        (remaining_users.users, was_relay, leaving_user_addr, lone_user_addr)
+                        (
+                            remaining_users.users,
+                            was_relay,
+                            leaving_user_addr,
+                            lone_user_addr,
+                        )
                     }; //lock dropped
 
                     //Notify lone user they are now relay
-                    if let Some(lone_user_addr) = lone_user_addr{
+                    if let Some(lone_user_addr) = lone_user_addr {
                         let reply = "MODE RELAY\n";
-                        if let Err(e) = socket.send_to(reply.as_bytes(), lone_user_addr).await{
+                        if let Err(e) = socket.send_to(reply.as_bytes(), lone_user_addr).await {
                             eprintln!("Failed to notify lone user: {}", e);
                         }
                     }
 
                     //If the leaving user was the relay and there are still users, promote the first and notify
-                    if was_relay && remaining_users.len() > 1{
+                    if was_relay && remaining_users.len() > 1 {
                         let new_relay = &remaining_users[0];
-                        if let Err(e) = socket.send_to("MODE RELAY\n".as_bytes(), new_relay.addr).await{
-                            eprintln!("Failed to notify {} about new relay: {}", new_relay.name, e);
+                        if let Err(e) = socket
+                            .send_to("MODE RELAY\n".as_bytes(), new_relay.addr)
+                            .await
+                        {
+                            eprintln!(
+                                "Failed to notify {} about promotion to relay: {}",
+                                new_relay.name, e
+                            );
                         }
 
                         for user in remaining_users.iter().skip(1) {
-                            let msg = format!("MODE DIRECT {} {}\n", new_relay.name, new_relay.addr);
-                            if let Err(e) = socket.send_to(msg.as_bytes(), user.addr).await{
+                            let msg =
+                                format!("MODE DIRECT {} {}\n", new_relay.name, new_relay.addr);
+                            if let Err(e) = socket.send_to(msg.as_bytes(), user.addr).await {
                                 eprintln!("Failed to notify {} about new relay: {}", user.name, e);
+                            }
+                        }
+
+                        for user in remaining_users.iter().skip(1) {
+                            let msg = format!("MODE DIRECT {} {}\n", user.name, user.addr);
+                            if let Err(e) = socket.send_to(msg.as_bytes(), new_relay.addr).await {
+                                eprintln!(
+                                    "Failed to notify {} about connected users: {}",
+                                    new_relay.name, e
+                                );
                             }
                         }
                     }
 
                     //Notify remaining users about the departure
                     for user in remaining_users {
-                        let departure_msg = format!("USER_LEFT {} {}\n", user_name, leaving_user_addr.map(|a| a.to_string()).unwrap_or_else(|| "0.0.0.0:0".into()));
-                        if let Err(e) = socket.send_to(departure_msg.as_bytes(), user.addr).await{
+                        let departure_msg = format!(
+                            "USER_LEFT {} {}\n",
+                            user_name,
+                            leaving_user_addr
+                                .map(|a| a.to_string())
+                                .unwrap_or_else(|| "0.0.0.0:0".into())
+                        );
+                        if let Err(e) = socket.send_to(departure_msg.as_bytes(), user.addr).await {
                             eprintln!("Failed to notify {} about departure: {}", user.name, e);
                         }
                     }
@@ -415,8 +530,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                     let remaining = {
                         let mut st = state.lock().await;
-                        if let Some(channels) = st.get_mut(&server_id){
-                            if let Some(channel) = channels.get_mut(&channel_name){
+                        if let Some(channels) = st.get_mut(&server_id) {
+                            if let Some(channel) = channels.get_mut(&channel_name) {
                                 //removing by name
                                 channel.users.retain(|u| u.name != peer_user);
 
@@ -432,15 +547,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             .cloned()
                     };
 
-                    if let Some(channel) = remaining{
-                        for u in channel.users{
-                            let _ = socket.send_to(format!("USER_LEFT {} 0.0.0.0:0\n", peer_user).as_bytes(), u.addr).await;    
+                    if let Some(channel) = remaining {
+                        for u in channel.users {
+                            let _ = socket
+                                .send_to(
+                                    format!("USER_LEFT {} 0.0.0.0:0\n", peer_user).as_bytes(),
+                                    u.addr,
+                                )
+                                .await;
                         }
                     }
                 }
 
                 _ => {
-                println!("Unknown/Bad packet from {}: {}", src, msg.trim());
+                    println!("Unknown/Bad packet from {}: {}", src, msg.trim());
                 }
             }
         }
@@ -448,11 +568,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 //helper to iterate notify_msgs (to avoid moving Vec in pattern)
-fn to_cleanup_and_notify_iter<I>(it:I) -> Vec<(Vec<SocketAddr>, Vec<u8>)>
-    where I: IntoIterator<Item = (Vec<SocketAddr>, Vec<u8>)>,
-    {
-        it.into_iter().collect()
-    }
-            
-        
-   
+fn to_cleanup_and_notify_iter<I>(it: I) -> Vec<(Vec<SocketAddr>, Vec<u8>)>
+where
+    I: IntoIterator<Item = (Vec<SocketAddr>, Vec<u8>)>,
+{
+    it.into_iter().collect()
+}


### PR DESCRIPTION
## After completing the previous tasks for the [od-nat-piercer] protocol, i implemented the foundation for it.
### The protocol now has multiple active threads when needed, the server acts as RELAY when a single user joins a server, and sends heartbeat messages (send PING/receive PONG) to keep NAT alive. 
### If one or more users join the channel, the first user becomes RELAY. The users that want to connect will send UDP hole-punches until they establish connection. After connection is established, the users connected will be added to a peers list, that will be passed to the RELAY, and he will start a keepalive thread to send heartbeat messages, just like the server did, to maintain the connections alive.
### If the RELAY user is timing out, or leaves the channel, the second user from the channel.users list will become relay, will receive the list of connected peers, and will maintain the connection alive with them.
### The protocol works in a STAR topology.