### PR TITLE
First approach in trying to solve Complex NAT problems. Still needs some work.

### DIFF
--- a/src/client/structures.rs
+++ b/src/client/structures.rs
@@ -7,4 +7,6 @@ pub struct PeerInfo {
     pub last_pong: Instant,
     pub username: String,
     pub connected: bool,
+
+    pub created_at: Instant,
 }

--- a/src/signaling/handlers/message.rs
+++ b/src/signaling/handlers/message.rs
@@ -7,6 +7,7 @@ use super::{
     disconnect::handle_disconnect_message,
     heartbeat::{handle_heartbeat, handle_pong},
     notifications::handle_peer_timeout,
+    request_relay::{handle_data_from_client, handle_relay_request},
 };
 
 pub async fn handle_message(
@@ -39,6 +40,14 @@ pub async fn handle_message(
 
             "PEER_TIMEOUT" if parts.len() >= 4 => {
                 handle_peer_timeout(&parts, src, socket, state).await;
+            }
+
+            "REQUEST_RELAY" if parts.len() >= 4 => {
+                handle_relay_request(&parts, src, socket, state).await;
+            }
+
+            "DATA" if parts.len() >= 3 => {
+                handle_data_from_client(&msg, src, socket, state).await;
             }
 
             _ => {

--- a/src/signaling/handlers/mod.rs
+++ b/src/signaling/handlers/mod.rs
@@ -3,6 +3,7 @@ pub mod disconnect;
 pub mod heartbeat;
 pub mod message;
 pub mod notifications;
+pub mod request_relay;
 pub mod utils;
 
 pub use message::handle_message;

--- a/src/signaling/handlers/request_relay.rs
+++ b/src/signaling/handlers/request_relay.rs
@@ -1,0 +1,61 @@
+use crate::signaling::structures::ServerMap;
+use std::{net::SocketAddr, sync::Arc};
+use tokio::{net::UdpSocket, sync::Mutex};
+
+pub async fn handle_relay_request(
+    parts: &[&str],
+    _src: SocketAddr,
+    socket: Arc<UdpSocket>,
+    state: Arc<Mutex<ServerMap>>,
+) {
+    // Relay request <server_id> <channel> <username>
+    if parts.len() < 4 {
+        return;
+    }
+    let server_id = parts[1];
+    let channel_name = parts[2];
+    let username = parts[3];
+
+    let mut st = state.lock().await;
+    if let Some(channels) = st.get_mut(server_id) {
+        if let Some(channel) = channels.get_mut(channel_name) {
+            channel.need_server_relay.insert(username.to_string());
+
+            // notify all users that the server will forward for the user that needs a relay
+            let notify = format!("MODE SERVER_RELAY {}\n", username);
+            for u in channel.users.iter() {
+                let _ = socket.send_to(notify.as_bytes(), u.addr).await;
+            }
+        }
+    }
+}
+
+pub async fn handle_data_from_client(
+    raw: &str,
+    src: SocketAddr,
+    socket: Arc<UdpSocket>,
+    state: Arc<Mutex<ServerMap>>,
+) {
+    let parts: Vec<&str> = raw.splitn(3, ' ').collect();
+    if parts.len() < 3 {
+        return;
+    }
+    let sender = parts[1];
+
+    //find channel and user by src addr and sender name
+    let mut st = state.lock().await;
+    for (_sid, channels) in st.iter_mut() {
+        for (_cname, channel) in channels.iter_mut() {
+            if let Some(_user_in_channel) = channel
+                .users
+                .iter()
+                .position(|u| u.addr == src && u.name == sender)
+            {
+                for peer in channel.users.iter().filter(|p| p.addr != src) {
+                    let _ = socket.send_to(raw.as_bytes(), peer.addr).await;
+                }
+                return;
+            }
+        }
+    }
+}

--- a/src/signaling/structures.rs
+++ b/src/signaling/structures.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, net::SocketAddr, time::Instant};
+use std::{
+    collections::{HashMap, HashSet},
+    net::SocketAddr,
+    time::Instant,
+};
 
 #[derive(Clone, Debug)]
 pub struct User {
@@ -11,6 +15,8 @@ pub struct User {
 pub struct Channel {
     pub users: Vec<User>,
     pub relay: Option<String>,
+
+    pub need_server_relay: HashSet<String>,
 }
 
 pub type ServerMap = HashMap<String, HashMap<String, Channel>>;


### PR DESCRIPTION
## od-nat-piercer did work for only Full Cone NAT Types. Symmetric NAT would not allow the protocol to establish connection between users.
### This is my first try to solve the problem
## What i tried to change:
### Server side:
- updated the Channel structure inside /signaling/structures.rs with a small addition, i added **need_server_relay** HashSet, a per-channel set of usernames that the server will relay for (meaning the users that cannot achieve connection after a few seconds because of NAT)
- in /signaling/handlers/ i needed to add a new handler file, called **request_relay.rs** that contains 2 new handlers:
  - 'handle_relay_request' - when the server will receive **RELAY_REQUEST**, this handler function will add that user to the 'neet_server_relay' list for corresponding channel and will notify all users that the server will act as relay for the requesting user
  - 'handle_data_from_client' - when server receives **DATA** packet from a client, this function will forward it to the other users in the same channel
- updated /signaling/handlers/message.rs file to call the new server relay handlers described above

### Client side:
- inside the PeerInfo structure, i added a 'created_at' variable, a timestamp of when a peer was added (when the hole punch attemtps started)
- i needed to add a parameter to keep in mind when we will need the server to be the relay for specific users, so i created a **server_relay_enabled** and added it to many places when needed:
  - i created a new handler, called 'handle_mode_server_relay_for', that takes a server_relay_flag, sets it to **true** for the user that needs server relay, and prints a notification that the traffic is relayed by the server for current user.
  - this new function is used in 'handle_mode_line' handler, when it receives the "SERVER_RELAY" message
- inside /client/networking.rs the majority of the functions needed to be updated to use the new **server_relay_enabled** parameter  
  - the 'relay_main_loop' checks after 5 seconds if the peer is still not connected, which means it didn't manage to establish a connection or start a correct UDP Hole-Punch because of symmetric NAT, and sends a REQUEST_RELAY message, which will start handling the case of user having complex NAT
 
