### PR TITLE
NAT symmetric logic, eligible users as relays, successfull connections logs, fixed false server responses

### DIFF
--- a/src/client/networking.rs
+++ b/src/client/networking.rs
@@ -193,7 +193,7 @@ pub fn start_relay_keepalive(
     server_id: String,
     channel: String,
     signaling_addr: String,
-    server_relay_enabled: Arc<Mutex<bool>>,
+    channel_has_server_relays: Arc<Mutex<bool>>,
 ) {
     thread::spawn(move || {
         relay_keepalive_loop(
@@ -204,7 +204,7 @@ pub fn start_relay_keepalive(
             server_id,
             channel,
             signaling_addr,
-            server_relay_enabled,
+            channel_has_server_relays,
         );
     });
 }

--- a/src/client/structures.rs
+++ b/src/client/structures.rs
@@ -7,6 +7,7 @@ pub struct PeerInfo {
     pub last_pong: Instant,
     pub username: String,
     pub connected: bool,
-
     pub created_at: Instant,
+    pub use_server_relay: bool, //server will carry traffic for this peer
+    pub relay_requested: bool,  //we asked server once
 }

--- a/src/client/structures.rs
+++ b/src/client/structures.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::Instant;
 
 #[derive(Clone, Debug)]
@@ -11,3 +12,17 @@ pub struct PeerInfo {
     pub use_server_relay: bool, //server will carry traffic for this peer
     pub relay_requested: bool,  //we asked server once
 }
+
+#[derive(Debug)]
+pub struct PunchState {
+    pub paused: bool,
+}
+
+pub type PunchSync = Arc<(Mutex<PunchState>, Condvar)>;
+
+#[derive(Debug)]
+pub struct RelayState {
+    pub is_active: bool, // = is_relay || channel_has_server_relays
+}
+
+pub type RelaySync = Arc<(Mutex<RelayState>, Condvar)>;

--- a/src/signaling/handlers/disconnect.rs
+++ b/src/signaling/handlers/disconnect.rs
@@ -26,6 +26,9 @@ pub async fn handle_disconnect_message(
         lone_user_addr,
         &user_name,
         socket,
+        &Arc::clone(&state),
+        server_id,
+        channel_name,
     )
     .await;
 }

--- a/src/signaling/handlers/notifications.rs
+++ b/src/signaling/handlers/notifications.rs
@@ -7,7 +7,7 @@ fn pick_eligible_relay(channel: &Channel) -> Option<User> {
     channel
         .users
         .iter()
-        .find(|u| !channel.need_server_relay.contains(&u.name))
+        .find(|u| !u.needs_server_relay)
         .cloned()
 }
 

--- a/src/signaling/handlers/notifications.rs
+++ b/src/signaling/handlers/notifications.rs
@@ -2,6 +2,15 @@ use crate::signaling::structures::{Channel, ServerMap, User};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{net::UdpSocket, sync::Mutex};
 
+fn pick_eligible_relay(channel: &Channel) -> Option<User> {
+    // Primul user care NU e in need_server_relay (adica nu are NAT symmetric)
+    channel
+        .users
+        .iter()
+        .find(|u| !channel.need_server_relay.contains(&u.name))
+        .cloned()
+}
+
 pub async fn mark_relay_in_channel(
     state: &Arc<Mutex<ServerMap>>,
     server_id: &str,
@@ -162,13 +171,36 @@ pub async fn handle_multiple_users_scenario(
     socket: &Arc<UdpSocket>,
     state: &Arc<Mutex<ServerMap>>,
 ) {
-    let relay_user = &users_to_notify.users[0];
-    let peers = &users_to_notify.users[1..];
+    if let Some(relay_user) = pick_eligible_relay(users_to_notify) {
+        let peers: Vec<User> = users_to_notify
+            .users
+            .iter()
+            .cloned()
+            .filter(|u| u.name != relay_user.name)
+            .collect();
 
-    mark_relay_in_channel(state, server_id, channel_name, relay_user).await;
-    notify_relay_about_peers(socket, relay_user, peers).await;
-    notify_peers_about_relay(socket, relay_user, peers).await;
-    send_relay_mode_to_relay(socket, relay_user).await;
+        mark_relay_in_channel(state, server_id, channel_name, &relay_user).await;
+        notify_relay_about_peers(socket, &relay_user, &peers).await;
+        notify_peers_about_relay(socket, &relay_user, &peers).await;
+        send_relay_mode_to_relay(socket, &relay_user).await;
+    } else {
+        // nici un user eligibil -> nu promovam pe nimeni, lasam serverul ca relay
+        // anuntam ca serverul va face relay pentru fiecare user din canal
+        for u in &users_to_notify.users {
+            let notify = format!("MODE SERVER_RELAY {}\n", u.name);
+            for usr in &users_to_notify.users {
+                let _ = socket.send_to(notify.as_bytes(), usr.addr).await;
+            }
+        }
+
+        // si marcam in state ca nu exista relay de user
+        let mut st = state.lock().await;
+        if let Some(chans) = st.get_mut(server_id) {
+            if let Some(ch) = chans.get_mut(channel_name) {
+                ch.relay = None;
+            }
+        }
+    }
 }
 
 pub async fn handle_single_user_scenario(
@@ -183,15 +215,59 @@ pub async fn handle_single_user_scenario(
 pub async fn handle_relay_transition(
     socket: &Arc<UdpSocket>,
     was_relay: bool,
-    remaining_users: &[User],
+    state: &Arc<Mutex<ServerMap>>,
+    server_id: &str,
+    channel_name: &str,
 ) {
-    if was_relay && remaining_users.len() > 1 {
-        let new_relay = &remaining_users[0];
-        let peers = &remaining_users[1..];
+    if !was_relay {
+        return;
+    }
 
-        promote_new_relay(socket, new_relay).await;
-        notify_peers_about_new_relay(socket, new_relay, peers).await;
-        notify_new_relay_about_peers(socket, new_relay, peers).await;
+    //luam canalul curent ca sa vedem users + need_server_relay
+    let channel_opt = {
+        let st = state.lock().await;
+        st.get(server_id)
+            .and_then(|chans| chans.get(channel_name))
+            .cloned()
+    };
+
+    if let Some(channel) = channel_opt {
+        //alegem un nou relay eligibil
+        if let Some(new_relay) = pick_eligible_relay(&channel) {
+            let peers: Vec<User> = channel
+                .users
+                .iter()
+                .cloned()
+                .filter(|u| u.name != new_relay.name)
+                .collect();
+
+            promote_new_relay(socket, &new_relay).await;
+            notify_peers_about_new_relay(socket, &new_relay, &peers).await;
+            notify_new_relay_about_peers(socket, &new_relay, &peers).await;
+
+            //actualizam relay in state
+            let mut st = state.lock().await;
+            if let Some(chans) = st.get_mut(server_id) {
+                if let Some(ch) = chans.get_mut(channel_name) {
+                    ch.relay = Some(new_relay.name.clone());
+                }
+            }
+        } else {
+            //nici un user eligibil -> ramane serverul ca relay, anuntam SERVER_RELAY pentru toti
+            for u in &channel.users {
+                let notify = format!("MODE SERVER_RELAY {}\n", u.name);
+                for usr in &channel.users {
+                    let _ = socket.send_to(notify.as_bytes(), usr.addr).await;
+                }
+            }
+
+            let mut st = state.lock().await;
+            if let Some(chans) = st.get_mut(server_id) {
+                if let Some(ch) = chans.get_mut(channel_name) {
+                    ch.relay = None;
+                }
+            }
+        }
     }
 }
 
@@ -202,9 +278,12 @@ pub async fn handle_disconnect_notifications(
     lone_user_addr: Option<SocketAddr>,
     user_name: &str,
     socket: Arc<UdpSocket>,
+    state: &Arc<Mutex<ServerMap>>,
+    server_id: String,
+    channel_name: String,
 ) {
     notify_lone_user(&socket, lone_user_addr).await;
-    handle_relay_transition(&socket, was_relay, &remaining_users).await;
+    handle_relay_transition(&socket, was_relay, &state, &server_id, &channel_name).await;
     notify_all_about_departure(&socket, remaining_users, user_name, leaving_user_addr).await;
 }
 

--- a/src/signaling/handlers/utils.rs
+++ b/src/signaling/handlers/utils.rs
@@ -47,6 +47,7 @@ pub async fn create_new_user(user_name: &str, src_addr: SocketAddr) -> User {
         name: user_name.to_string(),
         addr: src_addr,
         last_pong: Instant::now(),
+        needs_server_relay: false,
     }
 }
 

--- a/src/signaling/heartbeat.rs
+++ b/src/signaling/heartbeat.rs
@@ -1,41 +1,81 @@
-use crate::signaling::{structures::ServerMap, utils::cleanup_and_notify_iter};
+use crate::signaling::{
+    structures::{Channel, ServerMap, User},
+    utils::cleanup_and_notify_iter,
+};
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::{net::UdpSocket, sync::Mutex};
+
+fn pick_eligible_relay(channel: &Channel) -> Option<User> {
+    // First user that is NOT in need_server_relay (meaning he doesn't have Symmetric NAT)
+    channel
+        .users
+        .iter()
+        .find(|u| !channel.need_server_relay.contains(&u.name))
+        .cloned()
+}
 
 fn handle_relay_timeout(
     channel: &mut crate::signaling::structures::Channel,
     notifications: &mut Vec<(Vec<SocketAddr>, Vec<u8>)>,
 ) {
-    if !channel.users.is_empty() {
-        let new_relay = channel.users[0].name.clone();
-        channel.relay = Some(new_relay.clone());
+    if let Some(new_relay_user) = pick_eligible_relay(channel) {
+        //setting the new relay in channel
+        channel.relay = Some(new_relay_user.name.clone());
 
-        let new_relay_addr = channel.users[0].addr;
+        //1) Send MODE RELAY just to the new relay
+        notifications.push((vec![new_relay_user.addr], b"MODE RELAY\n".to_vec()));
 
-        notifications.push((vec![new_relay_addr], b"MODE RELAY\n".to_vec()));
-
-        let mut relinfo_msg = Vec::new();
-        for _peer in channel.users.iter().skip(1) {
-            let m = format!("MODE DIRECT {} {}\n", new_relay, new_relay_addr);
-            relinfo_msg.extend_from_slice(m.as_bytes());
+        //2) Send to every peer: "MODE DIRECT <relay_name> <relay_addr>"
+        let peers_addrs: Vec<SocketAddr> = channel
+            .users
+            .iter()
+            .filter(|u| u.name != new_relay_user.name)
+            .map(|u| u.addr)
+            .collect();
+        if !peers_addrs.is_empty() {
+            let mut payload = Vec::new();
+            for _peer in channel
+                .users
+                .iter()
+                .filter(|u| u.name != new_relay_user.name)
+            {
+                let m = format!(
+                    "MODE DIRECT {} {}\n",
+                    new_relay_user.name, new_relay_user.addr
+                );
+                payload.extend_from_slice(m.as_bytes());
+            }
+            notifications.push((peers_addrs, payload));
         }
-        if !relinfo_msg.is_empty() {
-            let others_addrs: Vec<SocketAddr> =
-                channel.users.iter().skip(1).map(|u| u.addr).collect();
-            notifications.push((others_addrs, relinfo_msg));
-        }
 
+        // 3) Send new relay info about all other peers: "MODE DIRECT <peer> <addr>"
         let mut peers_to_new_msg = Vec::new();
-        for peer in channel.users.iter().skip(1) {
+        for peer in channel
+            .users
+            .iter()
+            .filter(|u| u.name != new_relay_user.name)
+        {
             let m = format!("MODE DIRECT {} {}\n", peer.name, peer.addr);
             peers_to_new_msg.extend_from_slice(m.as_bytes());
         }
-
         if !peers_to_new_msg.is_empty() {
-            notifications.push((vec![new_relay_addr], peers_to_new_msg));
+            notifications.push((vec![new_relay_user.addr], peers_to_new_msg));
         }
     } else {
+        //No eligible user -> no RELAY
+        // we just keep the server as relay (send MODE SERVER_RELAY <user> to all users)
         channel.relay = None;
+        if !channel.users.is_empty() {
+            let mut payload = Vec::new();
+            for u in &channel.users {
+                let m = format!("MODE SERVER_RELAY {}\n", u.name);
+                payload.extend_from_slice(m.as_bytes());
+            }
+
+            //send to all users from channel
+            let all_addrs: Vec<SocketAddr> = channel.users.iter().map(|u| u.addr).collect();
+            notifications.push((all_addrs, payload));
+        }
     }
 }
 
@@ -112,7 +152,23 @@ fn process_channel_heartbeat(
     }
 
     if channel.users.len() == 1 {
-        pings.push(channel.users[0].addr);
+        //one lone user, if he's eligible, we keep him as relay, otherwise the server remains relay
+        let solo = channel.users[0].clone();
+        let is_eligible = !channel.need_server_relay.contains(&solo.name);
+
+        if is_eligible {
+            pings.push(solo.addr);
+            channel.relay = Some(solo.name.clone());
+        } else {
+            //not eligible, don't promote him as relay, keep server as relay
+            channel.relay = None;
+
+            //announce it
+            notifications.push((
+                vec![solo.addr],
+                format!("MODE SERVER_RELAY {}\n", solo.name).into_bytes(),
+            ));
+        }
     }
 
     if channel.users.is_empty() {

--- a/src/signaling/heartbeat.rs
+++ b/src/signaling/heartbeat.rs
@@ -10,7 +10,7 @@ fn pick_eligible_relay(channel: &Channel) -> Option<User> {
     channel
         .users
         .iter()
-        .find(|u| !channel.need_server_relay.contains(&u.name))
+        .find(|u| !u.needs_server_relay)
         .cloned()
 }
 
@@ -154,7 +154,7 @@ fn process_channel_heartbeat(
     if channel.users.len() == 1 {
         //one lone user, if he's eligible, we keep him as relay, otherwise the server remains relay
         let solo = channel.users[0].clone();
-        let is_eligible = !channel.need_server_relay.contains(&solo.name);
+        let is_eligible = !solo.needs_server_relay;
 
         if is_eligible {
             pings.push(solo.addr);

--- a/src/signaling/structures.rs
+++ b/src/signaling/structures.rs
@@ -1,22 +1,17 @@
-use std::{
-    collections::{HashMap, HashSet},
-    net::SocketAddr,
-    time::Instant,
-};
+use std::{collections::HashMap, net::SocketAddr, time::Instant};
 
 #[derive(Clone, Debug)]
 pub struct User {
     pub name: String,
     pub addr: SocketAddr,
     pub last_pong: Instant,
+    pub needs_server_relay: bool,
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct Channel {
     pub users: Vec<User>,
     pub relay: Option<String>,
-
-    pub need_server_relay: HashSet<String>,
 }
 
 pub type ServerMap = HashMap<String, HashMap<String, Channel>>;


### PR DESCRIPTION
# NAT-symmetric support + cleaning client behavior

## 1) I kind of transformed our server into a TURN-like(Travel Using Relays around NAT) server for symmetric NATs
When two peers can't punch through, we need the server to relay traffic.
Changes I've made:
- **/src/signaling/handlers/request_relay.rs**
  - **REQUEST_RELAY <server_id> <channel> <username>** marks the user in Channel.need_server_relay
  - **handle_data_from_client()** validates sender and forwards **DATA** to all other users (server acts as relay)
- **/src/client/bin/client.rs**
  - added new flag **send_via_server** - when I must send via server (I'm symmetric or lone), and renamed the old **server_relay_enabled** flag to **channel_has_server_relays** (when I'm relay, mirror what I forward to server as well, because some peers are server-relayed), to make more sense
  - in **process_server_response()**
    - On **MODE SERVER_RELAY <me>** -> sets send_via_server = true ("I will send via server from now on")
    - On **MODE SERVER_RELAY <other>** and if I'm relay -> sets channel_has_server_relays = true ("Relay will also mirror traffic to server")
- **/src/client/networking.rs**
  - **hole_punching_loop()**
    - now uses the new flag **send_via_server**: it sends hole punch only to eligible peers, but peers marked with use_server_relay true, or already connected users are skipped. This way, the hole punches stop when connection with Symmetric NAT users is impossible to achieve.
    - i also added a backoff, which is a HashMap<String, u64> (key = username, value = delay in milliseconds). For every punching try for a peer, the backoff is doubled: initially 500ms, then 1000ms, then 2000ms, at max of 3000ms.
    - Why is it useful? Well, i don't want to send HOLE_PUNCH very very often, as the protocol used to do, it wastes traffic. This way we send less punches after the first tries, we save resources and the logs don't explode. Basically, the punches gradually decrease.
    - First tries are still fast (500ms -> 1s), and we make them more rare as time passes.
    - It helps with my logic of **REQUEST_RELAY** and **MODE SERVER_RELAY**, because after a few seconds the connection is not established, it goes into the **REQUEST RELAY** logic.

## 2) Talking about eligible peers :)
- Because we now have different logics to handle different NAT types, of course i needed to add a check for eligibility of a user.
- What i mean by this is, that i added in **/src/signaling/notifications.rs** and **/src/signaling/heartbeat.rs** the function **pick_eligible_relay**, that checks if a user is on Symmetric NAT (basically if it needs SERVER RELAY), or not.
- We need this check because, in many functions, the promotion of a user relay was made by simply picking the first user in a channel user list to be relay. Well, we don't want a Symmetric NAT user to act as relay for the others, because it would make no sense. All the traffic would need to pass through the server. SO, i check every time a user has to be promoted to relay, or the relay left and we need a new one, and in all kinds of scenarios, if the next relay, would be eligible or not!

## 3) We now have a clear "peer connected" log, when a peer establishes connection
I've made this change so we know every time a DIRECT or SERVER-RELAYED connection is established.
- in **/src/client/handlers.rs**
  - added a one-time print everytime a connection is established, and mark it as **(direct)** or **(via server)**
  - so now after a normal user is connected we should see in the logs something like: "Peer X is now CONNECTED (direct) at ...", and when a Symmetric user is connected: "Peer X is now CONNECTED (via server) ..."

## 4) No more weird "Server response: PING/HOLE_PUNCH"
During setup, peer packets could be misread as "server responses", that would print weird logs.
So i added this logic: in **/src/bin/client.rs**, the signaling endpoint is now a concrete SocketAddr, so we now classify packets by comparing **socket addresses**.
- So, if **src == server_socketaddr** -> treat as server, else treat as peer, so no more "Server response: " prints from peers packets
One more change that helps with this, is that if a server packet contains **"MODE ..."** line, we exit early from setup, so we immediately switch to the main loop.

## 5) Added the necessary fields inside PeerInfo structure 
