### PR TITLE
Few bugs fixed that could potentially cause connection problems.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ local-ip-address = "0.6.5"
 tokio = { version = "1", features = ["full"]}
 warp = "0.3"
 reqwest = { version = "0.11", features = ["blocking"] }
+

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -355,6 +355,8 @@ fn main() -> std::io::Result<()> {
         user.to_string(),
         Arc::clone(&send_via_server),
         signaling_addr.clone(),
+        Arc::clone(&is_relay),
+        Arc::clone(&channel_has_server_relays),
     );
 
     main_loop(

--- a/src/signaling/handlers/utils.rs
+++ b/src/signaling/handlers/utils.rs
@@ -53,7 +53,7 @@ pub async fn create_new_user(user_name: &str, src_addr: SocketAddr) -> User {
 
 pub async fn handle_lone_user_scenario(channel: &mut Channel, socket: &Arc<UdpSocket>) {
     if channel.relay.is_none() && channel.users.len() == 1 {
-        let reply = "MODE SERVER_RELAY\n";
+        let reply = format!("MODE SERVER_RELAY {}\n", channel.users[0].name);
         if let Err(e) = socket
             .send_to(reply.as_bytes(), channel.users[0].addr)
             .await
@@ -61,7 +61,7 @@ pub async fn handle_lone_user_scenario(channel: &mut Channel, socket: &Arc<UdpSo
             eprintln!("Failed to notify lone user about server relay: {}", e);
         }
 
-        channel.relay = Some(channel.users[0].name.clone());
+        channel.relay = None;
     }
 }
 


### PR DESCRIPTION
## 1. In /client/networking.rs:
- i needed to complete the user input/message sending functions by adding the ```is_relay``` and ```channel_has_server_relays``` flags to functions:
    - ```handle_user_message```
    - ```user_input_loop```
    - ```start_user_input```
- separated the case where i send the message directly to users that are not server relayed   
- added the case where **i am relay, so i need to mirror to server so the symmetric users can receive my message**

## 2. In /signaling/handlers/utils.rs:
- in ```handle_lone_user_scenario```
    - needed to complete the "MODE SERVER_RELAY" message with the username, because other functions are dependent of having the username at the end of the message, this was an attention mistake when writing the code in the past
    - also here ```channel.relay``` has to be set to **None**, because setting it to the first user in the channel was an old method of selecting the channel relay that no longer works. An example of why this was wrong is that, if a user with symmetric NAT joins the channel first, he would be set as relay, which would be wrong, because nobody could connect to him, and for the next user that's connecting, even if he would have permissive NAT, his traffic would be relayed by the server.
    
