### PR TITLE
Fixed regarding duplicate server relayed messages and no reason timeo…

### DIFF
--- a/src/client/networking.rs
+++ b/src/client/networking.rs
@@ -131,6 +131,10 @@ fn relay_main_loop(
         {
             let mut guard = peers.lock().unwrap();
             for (i, peer) in guard.iter_mut().enumerate() {
+                if peer.use_server_relay {
+                    continue;
+                }
+
                 if peer.last_pong.elapsed() > Duration::from_secs(PEER_TIMEOUT_SEC) {
                     handle_peer_timeout(socket, server_id, channel, peer, signaling_addr);
                     to_remove.push(i);

--- a/src/signaling/handlers/request_relay.rs
+++ b/src/signaling/handlers/request_relay.rs
@@ -95,6 +95,7 @@ pub async fn handle_data_from_client(
                             let _ = socket.send_to(raw.as_bytes(), peer.addr).await;
                         }
                     }
+                    return;
                 }
 
                 //otherwise (unexpected normal client sent to server?)


### PR DESCRIPTION
## Server-relayed peer's messages appeared duplicate
- in /signaling/handlers/request_relay.rs i needed to add a return in:
    - ```if sender_needs_server_relay``` statement, so it doesn't go into the next if statement to print the message again

## In /client/networking.rs, when the RELAY checks user last-pong to check if he's still alive, i needed to add a check if the user uses server relay, if yes, we need to skip him, because the server is actually keeping him alive.