### PR TITLE
Added binary packet header + demux, with temporary changes and testing.

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -7,10 +7,13 @@ use std::{
     time::{Duration, Instant},
 };
 
-use od_nat_piercer::client::{
-    handlers::*,
-    networking::*,
-    structures::{NatKind, PeerInfo, PunchState, PunchSync, RelayState, RelaySync},
+use od_nat_piercer::{
+    client::{
+        handlers::*,
+        networking::*,
+        structures::{NatKind, PeerInfo, PunchState, PunchSync, RelayState, RelaySync},
+    },
+    proto::packet::{self, BROADCAST, Header, Kind},
 };
 
 const SETUP_POLL_SLEEP_MS: u64 = 20;
@@ -76,6 +79,22 @@ fn update_relay_is_active(
         st.is_active = active;
         cvar.notify_all(); //starts/stops relay loop instantly
     }
+}
+
+fn send_control_test(socket: &UdpSocket, signaling_addr: &str) {
+    let payload = b"CONTROL_TEST\n";
+    let hdr = Header {
+        kind: Kind::Control,
+        flags: 0,
+        channel_id: 0,
+        src_peer_id: 0,
+        dst_peer_id: BROADCAST,
+        stream_id: 0,
+        payload_len: payload.len() as u16,
+    };
+
+    let pkt = packet::encode(hdr, payload);
+    let _ = socket.send_to(&pkt, signaling_addr);
 }
 
 fn process_server_response(
@@ -160,6 +179,72 @@ fn handle_recv_result(
 ) -> bool {
     match result {
         Ok((len, src)) => {
+            if let Some((hdr, payload)) = od_nat_piercer::proto::packet::decode(&buf[..len]) {
+                match hdr.kind {
+                    Kind::Control => {
+                        println!("(setup) Got CONTROL {} bytes from {}", payload.len(), src);
+
+                        //temporarly: if payload is text, process as before
+                        if let Ok(s) = std::str::from_utf8(payload) {
+                            println!("(setup) CONTROL payload: {}", s.trim());
+                            if &src == server_socketaddr {
+                                if s.lines().any(|l| l.trim_start().starts_with("MODE ")) {
+                                    *saw_mode = true;
+                                }
+
+                                // 1) Normal processing: MODE / DATA / USER_LEFT, etc
+                                process_incoming_message(
+                                    socket,
+                                    s,
+                                    src,
+                                    peers,
+                                    &user,
+                                    is_relay,
+                                    channel_has_server_relays,
+                                    signaling_addr,
+                                );
+
+                                // 2) Local mode + send_via_server / punching behaviors
+                                process_server_response(
+                                    s,
+                                    user,
+                                    is_relay,
+                                    channel_has_server_relays,
+                                    send_via_server,
+                                    punch_sync,
+                                );
+
+                                update_relay_is_active(
+                                    is_relay,
+                                    channel_has_server_relays,
+                                    relay_sync,
+                                );
+                            } else {
+                                // peer traffic (arrived during setup)
+                                handle_peer_message(peers, src);
+
+                                process_incoming_message(
+                                    socket,
+                                    s,
+                                    src,
+                                    peers,
+                                    &user,
+                                    is_relay,
+                                    channel_has_server_relays,
+                                    signaling_addr,
+                                );
+                            }
+                        }
+                    }
+                    Kind::Dtls => {
+                        println!("(setup) Got DTLS {} bytes from {}", payload.len(), src);
+                    }
+                    Kind::Srtp => {
+                        println!("(setup) Got SRTP {} bytes from {}", payload.len(), src);
+                    }
+                }
+                return true;
+            }
             let resp = String::from_utf8_lossy(&buf[..len]).to_string();
             if &src == server_socketaddr {
                 if resp.lines().any(|l| l.trim_start().starts_with("MODE ")) {
@@ -229,7 +314,7 @@ fn server_responses_during_setup(
     punch_sync: &PunchSync,
     relay_sync: &RelaySync,
 ) {
-    let mut buf = [0u8; 1024];
+    let mut buf = [0u8; 2048];
     let setup_deadline = Instant::now() + Duration::from_millis(SETUP_DEADLINE_MS);
     let mut saw_mode = false;
 
@@ -267,12 +352,37 @@ fn main_loop(
     relay_sync: &RelaySync,
     send_via_server: &Arc<AtomicBool>,
 ) -> std::io::Result<()> {
-    let mut buf = [0u8; 1024];
+    let mut buf = [0u8; 2048];
 
     println!("Starting main message loop...");
     loop {
         match socket.recv_from(&mut buf) {
             Ok((len, src)) => {
+                if let Some((hdr, payload)) = od_nat_piercer::proto::packet::decode(&buf[..len]) {
+                    match hdr.kind {
+                        Kind::Control => {
+                            println!("Got CONTROL {} bytes from {}", payload.len(), src);
+                            //temporarly: if payload is text, parse it as before
+                            if let Ok(s) = std::str::from_utf8(payload) {
+                                println!("CONTROL payload: {}", s.trim());
+                                process_incoming_message(
+                                    socket,
+                                    s,
+                                    src,
+                                    peers,
+                                    &user,
+                                    is_relay,
+                                    channel_has_server_relays,
+                                    signaling_addr,
+                                );
+                            }
+                        }
+                        Kind::Dtls => println!("Got DTLS {} bytes from {}", payload.len(), src),
+                        Kind::Srtp => println!("Got SRTP {} bytes from {}", payload.len(), src),
+                    }
+                    continue;
+                }
+
                 let message = String::from_utf8_lossy(&buf[..len]).to_string();
 
                 if &src == server_socketaddr {
@@ -352,6 +462,8 @@ fn main() -> std::io::Result<()> {
         &user,
         my_nat,
     );
+
+    send_control_test(&socket, &signaling_addr);
 
     let peers: Vec<PeerInfo> = Vec::new();
     let peers = Arc::new(Mutex::new(peers));

--- a/src/bin/signaling_server.rs
+++ b/src/bin/signaling_server.rs
@@ -28,13 +28,21 @@ async fn run_server(
     socket_probe: Arc<UdpSocket>,
     state: Arc<Mutex<ServerMap>>,
 ) {
-    let mut buf_main = [0u8; 1024];
-    let mut buf_probe = [0u8; 1024];
+    let mut buf_main = [0u8; 2048];
+    let mut buf_probe = [0u8; 2048];
 
     loop {
         tokio::select! {
             res = socket_main.recv_from(&mut buf_main) => {
                 if let Ok((len,src)) = res{
+                    if let Some((hdr, payload)) = od_nat_piercer::proto::packet::decode(&buf_main[..len]){
+                        if hdr.kind == od_nat_piercer::proto::packet::Kind::Control{
+                            if let Ok(s) = std::str::from_utf8(payload){
+                                handle_message(s.to_string(), src, Arc::clone(&socket_main), Arc::clone(&state)).await;
+                            }
+                        }
+                        continue;
+                    }
                     let msg = String::from_utf8_lossy(&buf_main[..len]).to_string();
                     handle_message(msg, src, Arc::clone(&socket_main), Arc::clone(&state)).await;
                 }
@@ -42,6 +50,15 @@ async fn run_server(
 
             res = socket_probe.recv_from(&mut buf_probe) => {
                 if let Ok((len,src)) = res{
+                    if let Some((hdr, payload)) = od_nat_piercer::proto::packet::decode(&buf_main[..len]){
+                        if hdr.kind == od_nat_piercer::proto::packet::Kind::Control{
+                            if let Ok(s) = std::str::from_utf8(payload){
+                                handle_message(s.to_string(), src, Arc::clone(&socket_probe), Arc::clone(&state)).await;
+                            }
+                        }
+                        continue;
+                    }
+
                     let msg = String::from_utf8_lossy(&buf_probe[..len]).to_string();
                     handle_message(msg, src, Arc::clone(&socket_probe), Arc::clone(&state)).await;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod client;
+pub mod proto;
 pub mod signaling;

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,0 +1,1 @@
+pub mod packet;

--- a/src/proto/packet.rs
+++ b/src/proto/packet.rs
@@ -88,3 +88,80 @@ pub fn decode(buf: &[u8]) -> Option<(Header, &[u8])> {
 
     Some((hdr, &buf[payload_start..payload_end]))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let payload = b"hello";
+        let h = Header {
+            kind: Kind::Control,
+            flags: 0x1224,
+            channel_id: 1,
+            src_peer_id: 2,
+            dst_peer_id: BROADCAST,
+            stream_id: 3,
+            payload_len: payload.len() as u16,
+        };
+
+        let buf = encode(h, payload);
+        let (h2, p2) = decode(&buf).expect("decode failed");
+        assert_eq!(h2.kind as u8, h.kind as u8);
+        assert_eq!(h2.flags, h.flags);
+        assert_eq!(h2.channel_id, h.channel_id);
+        assert_eq!(h2.src_peer_id, h.src_peer_id);
+        assert_eq!(h2.stream_id, h.stream_id);
+        assert_eq!(p2, payload);
+    }
+
+    #[test]
+    fn decode_rejects_bad_magic() {
+        let mut buf = vec![0u8; HEADER_LEN];
+        buf[0..4].copy_from_slice(b"XXXX");
+        assert!(decode(&buf).is_none());
+    }
+
+    #[test]
+    fn decode_rejects_bad_version() {
+        let payload = b"a";
+        let h = Header {
+            kind: Kind::Control,
+            flags: 0x1224,
+            channel_id: 1,
+            src_peer_id: 2,
+            dst_peer_id: BROADCAST,
+            stream_id: 3,
+            payload_len: payload.len() as u16,
+        };
+        let mut buf = encode(h, payload);
+        buf[4] = 99;
+        assert!(decode(&buf).is_none());
+    }
+
+    #[test]
+    fn kind_constants_table() {
+        assert_eq!(Kind::Control as u8, 1);
+        assert_eq!(Kind::Dtls as u8, 2);
+        assert_eq!(Kind::Srtp as u8, 3);
+    }
+
+    #[test]
+    fn decode_rejects_truncated_payload() {
+        let payload = b"abcd";
+        let h = Header {
+            kind: Kind::Control,
+            flags: 0,
+            channel_id: 0,
+            src_peer_id: 0,
+            dst_peer_id: BROADCAST,
+            stream_id: 0,
+            payload_len: payload.len() as u16,
+        };
+        let buf = encode(h, payload);
+        //truncate last byte
+        let truncated = &buf[..buf.len() - 1];
+        assert!(decode(truncated).is_none());
+    }
+}

--- a/src/proto/packet.rs
+++ b/src/proto/packet.rs
@@ -1,0 +1,90 @@
+pub const MAGIC: [u8; 4] = *b"ODNP";
+pub const VERSION: u8 = 1;
+pub const BROADCAST: u32 = 0xFFFF_FFFF;
+
+#[repr(u8)]
+// this is a rust attribute: when this enum is reprezented as a number (in memory/when we write is as bytes), use u8
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Kind {
+    Control = 1,
+    Dtls = 2,
+    Srtp = 3,
+}
+
+impl Kind {
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            1 => Some(Kind::Control),
+            2 => Some(Kind::Dtls),
+            3 => Some(Kind::Srtp),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Header {
+    pub kind: Kind,
+    pub flags: u16,
+    pub channel_id: u32,
+    pub src_peer_id: u32,
+    pub dst_peer_id: u32,
+    pub stream_id: u32,
+    pub payload_len: u16,
+}
+
+pub const HEADER_LEN: usize = 26;
+
+pub fn encode(h: Header, payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(HEADER_LEN + payload.len());
+    out.extend_from_slice(&MAGIC);
+    out.push(VERSION);
+    out.push(h.kind as u8);
+    out.extend_from_slice(&h.flags.to_le_bytes()); //to_le = to_little_endian - stores the least significant byte first, at the lowest memory address
+    out.extend_from_slice(&h.channel_id.to_le_bytes());
+    out.extend_from_slice(&h.src_peer_id.to_le_bytes());
+    out.extend_from_slice(&h.dst_peer_id.to_le_bytes());
+    out.extend_from_slice(&h.stream_id.to_le_bytes());
+    let len: u16 = payload.len().try_into().unwrap_or(u16::MAX);
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(&payload[..len as usize]);
+    out
+}
+
+pub fn decode(buf: &[u8]) -> Option<(Header, &[u8])> {
+    if buf.len() < HEADER_LEN {
+        return None;
+    }
+    if buf[0..4] != MAGIC {
+        return None;
+    }
+    if buf[4] != VERSION {
+        return None;
+    }
+    let kind = Kind::from_u8(buf[5])?;
+    let flags = u16::from_le_bytes([buf[6], buf[7]]);
+    let channel_id = u32::from_le_bytes(buf[8..12].try_into().ok()?);
+    let src_peer_id = u32::from_le_bytes(buf[12..16].try_into().ok()?);
+    let dst_peer_id = u32::from_le_bytes(buf[16..20].try_into().ok()?);
+    let stream_id = u32::from_le_bytes(buf[20..24].try_into().ok()?);
+    let payload_len = u16::from_le_bytes([buf[24], buf[25]]);
+    let payload_len = payload_len as usize;
+
+    let payload_start = HEADER_LEN;
+    let payload_end = payload_start.checked_add(payload_len)?;
+    if payload_end > buf.len() {
+        return None;
+    }
+
+    let hdr = Header {
+        kind,
+        flags,
+        channel_id,
+        src_peer_id,
+        dst_peer_id,
+        stream_id,
+        payload_len: payload_len as u16,
+    };
+
+    Some((hdr, &buf[payload_start..payload_end]))
+}

--- a/src/proto/packet.rs
+++ b/src/proto/packet.rs
@@ -3,7 +3,6 @@ pub const VERSION: u8 = 1;
 pub const BROADCAST: u32 = 0xFFFF_FFFF;
 
 #[repr(u8)]
-// this is a rust attribute: when this enum is reprezented as a number (in memory/when we write is as bytes), use u8
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Kind {
     Control = 1,
@@ -40,7 +39,7 @@ pub fn encode(h: Header, payload: &[u8]) -> Vec<u8> {
     out.extend_from_slice(&MAGIC);
     out.push(VERSION);
     out.push(h.kind as u8);
-    out.extend_from_slice(&h.flags.to_le_bytes()); //to_le = to_little_endian - stores the least significant byte first, at the lowest memory address
+    out.extend_from_slice(&h.flags.to_le_bytes());
     out.extend_from_slice(&h.channel_id.to_le_bytes());
     out.extend_from_slice(&h.src_peer_id.to_le_bytes());
     out.extend_from_slice(&h.dst_peer_id.to_le_bytes());
@@ -160,7 +159,6 @@ mod tests {
             payload_len: payload.len() as u16,
         };
         let buf = encode(h, payload);
-        //truncate last byte
         let truncated = &buf[..buf.len() - 1];
         assert!(decode(truncated).is_none());
     }

--- a/src/signaling/handlers/message.rs
+++ b/src/signaling/handlers/message.rs
@@ -1,3 +1,4 @@
+use crate::proto::packet::{BROADCAST, Header, Kind, encode};
 use crate::signaling::structures::ServerMap;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{net::UdpSocket, sync::Mutex};
@@ -54,6 +55,23 @@ pub async fn handle_message(
 
             "DATA" if parts.len() >= 3 => {
                 handle_data_from_client(&msg, src, socket, state).await;
+            }
+
+            "CONTROL_TEST" => {
+                println!("CONTROL_TEST from {}", src);
+
+                let payload = b"CONTROL_TEST_OK\n";
+                let hdr = Header {
+                    kind: Kind::Control,
+                    flags: 0,
+                    channel_id: 0,
+                    src_peer_id: 0,
+                    dst_peer_id: BROADCAST,
+                    stream_id: 0,
+                    payload_len: payload.len() as u16,
+                };
+                let pkt = encode(hdr, payload);
+                let _ = socket.send_to(&pkt, src).await;
             }
 
             _ => {


### PR DESCRIPTION
- Added new binary protocol module ```proto``` with packet header (MAGIC, VERSION) and Kind demux (CONTROL/DTLS/SRTP)
- Implemented ```encode()/decode()``` for the binary header + payload (little-endian fields, broadcast constant)
- Integrated binary packet demux in client runtime receive path:
	- ```main_loop```
	- ```handle_recv_result``` / setup receive path
	- i say **demux** because it works like a demultiplexer: we will receive on the same UDP socket many types of traffic (CONTROL, DTLS, SRTP). All of them come as bytes string. **Demux** means "write the header and decide towards which component i send the payload", Kind::Control, Kind::Dtls, Kind::Srtp.
	- with demux every component receives only the packets that belong to it: DTLS engine will receive DTLS, SRTP layer will receive SRTP, control handler will receive only CONTROL 
- Integrated binary packet decode on signaling server receive path (decode binar -> extract CONTROL payload -> forward into existing text handler for compatibility)
- Increased UDP receive buffers to 2048 bytes to support larger control/handshake packets
- Added ```CONTROL_TEST``` end-to-end test:
	- client sends binary ```CONTROL_TEST```
	- server logs it and replies with binary ```CONTROL_TEST_OK```
	- client decodes and logs ```CONTROL_TEST_OK```
- Kept backward compatibility: if ```decode()``` fails, fallback to old text-based message processing