### PR TITLE
(A2) Added channel/peer IDs and WELCOME control message.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,7 @@ name = "od-nat-piercer"
 version = "0.1.0"
 dependencies = [
  "local-ip-address",
+ "rand",
  "reqwest",
  "tokio",
  "warp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ local-ip-address = "0.6.5"
 tokio = { version = "1", features = ["full"]}
 warp = "0.3"
 reqwest = { version = "0.11", features = ["blocking"] }
+rand = "0.8"
 

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -3,7 +3,7 @@ use std::{
     net::{ToSocketAddrs, UdpSocket},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicU32, Ordering},
+        atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
     },
     thread,
     time::{Duration, Instant},
@@ -168,7 +168,7 @@ fn handle_recv_result(
     saw_mode: &mut bool,
     punch_sync: &PunchSync,
     relay_sync: &RelaySync,
-    channel_id: &Arc<AtomicU32>,
+    channel_id: &Arc<AtomicU64>,
     my_peer_id: &Arc<AtomicU32>,
 ) -> bool {
     match result {
@@ -316,7 +316,7 @@ fn server_responses_during_setup(
     signaling_addr: &str,
     punch_sync: &PunchSync,
     relay_sync: &RelaySync,
-    channel_id: &Arc<AtomicU32>,
+    channel_id: &Arc<AtomicU64>,
     my_peer_id: &Arc<AtomicU32>,
 ) {
     let mut buf = [0u8; 2048];
@@ -358,7 +358,7 @@ fn main_loop(
     punch_sync: &PunchSync,
     relay_sync: &RelaySync,
     send_via_server: &Arc<AtomicBool>,
-    channel_id: &Arc<AtomicU32>,
+    channel_id: &Arc<AtomicU64>,
     my_peer_id: &Arc<AtomicU32>,
 ) -> std::io::Result<()> {
     let mut buf = [0u8; 2048];
@@ -453,7 +453,7 @@ fn main() -> std::io::Result<()> {
     let socket = setup_socket(local_port);
 
     let my_peer_id = Arc::new(AtomicU32::new(0));
-    let channel_id = Arc::new(AtomicU32::new(0));
+    let channel_id = Arc::new(AtomicU64::new(0));
 
     // NAT detection before CONNECT
     let my_nat = detect_nat_kind(&socket, &signaling_ip);

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,8 +1,10 @@
 use std::{
     env,
     net::{ToSocketAddrs, UdpSocket},
-    sync::atomic::{AtomicBool, Ordering},
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU32, Ordering},
+    },
     thread,
     time::{Duration, Instant},
 };
@@ -13,7 +15,13 @@ use od_nat_piercer::{
         networking::*,
         structures::{NatKind, PeerInfo, PunchState, PunchSync, RelayState, RelaySync},
     },
-    proto::packet::{self, BROADCAST, Header, Kind},
+    proto::{
+        control_text::{
+            MSG_CONNECT, MSG_CONTROL, MSG_MODE, MSG_RELAY, MSG_SERVER_RELAY, NAT_TYPE_CONE,
+            NAT_TYPE_PUBLIC, NAT_TYPE_SYMMETRIC, NAT_TYPE_UNKNOWN,
+        },
+        packet::Kind,
+    },
 };
 
 const SETUP_POLL_SLEEP_MS: u64 = 20;
@@ -54,17 +62,17 @@ fn send_connect_message(
     my_nat: NatKind,
 ) {
     let nat_type = match my_nat {
-        NatKind::Symmetric => "SYMMETRIC",
-        NatKind::Cone => "CONE",
-        NatKind::Public => "PUBLIC",
-        NatKind::Unknown => "UNKOWN",
+        NatKind::Symmetric => NAT_TYPE_SYMMETRIC,
+        NatKind::Cone => NAT_TYPE_CONE,
+        NatKind::Public => NAT_TYPE_PUBLIC,
+        NatKind::Unknown => NAT_TYPE_UNKNOWN,
     };
 
-    let connect_msg = format!("CONNECT {} {} {} {}", server_id, channel, user, nat_type);
+    let connect_msg = format!("{MSG_CONNECT} {server_id} {channel} {user} {nat_type}");
     socket
         .send_to(connect_msg.as_bytes(), &signaling_addr)
         .expect("Failed to send CONNECT");
-    println!("Sent CONNECT to signaling server");
+    println!("Sent {MSG_CONNECT} to signaling server");
 }
 
 fn update_relay_is_active(
@@ -81,22 +89,6 @@ fn update_relay_is_active(
     }
 }
 
-fn send_control_test(socket: &UdpSocket, signaling_addr: &str) {
-    let payload = b"CONTROL_TEST\n";
-    let hdr = Header {
-        kind: Kind::Control,
-        flags: 0,
-        channel_id: 0,
-        src_peer_id: 0,
-        dst_peer_id: BROADCAST,
-        stream_id: 0,
-        payload_len: payload.len() as u16,
-    };
-
-    let pkt = packet::encode(hdr, payload);
-    let _ = socket.send_to(&pkt, signaling_addr);
-}
-
 fn process_server_response(
     response: &str,
     user: &str,
@@ -107,7 +99,7 @@ fn process_server_response(
 ) {
     if !response
         .lines()
-        .any(|l| l.trim_start().starts_with("MODE "))
+        .any(|l| l.trim_start().starts_with(&format!("{MSG_MODE} ")))
     {
         return;
     }
@@ -115,7 +107,7 @@ fn process_server_response(
     for line in response.lines() {
         let line = line.trim();
 
-        if line == "MODE RELAY" {
+        if line == format!("{MSG_MODE} {MSG_RELAY}") {
             if send_via_server.load(Ordering::Acquire) {
                 send_via_server.store(false, Ordering::Release);
                 println!("I am relay now - stop sending via server.");
@@ -130,7 +122,7 @@ fn process_server_response(
             }
         }
 
-        if line.starts_with("MODE SERVER_RELAY ") {
+        if line.starts_with(&format!("{MSG_MODE} {MSG_SERVER_RELAY} ")) {
             // MODE SERVER_RELAY <username>
             let parts: Vec<&str> = line.split_whitespace().collect();
             if parts.len() >= 3 {
@@ -176,19 +168,27 @@ fn handle_recv_result(
     saw_mode: &mut bool,
     punch_sync: &PunchSync,
     relay_sync: &RelaySync,
+    channel_id: &Arc<AtomicU32>,
+    my_peer_id: &Arc<AtomicU32>,
 ) -> bool {
     match result {
         Ok((len, src)) => {
             if let Some((hdr, payload)) = od_nat_piercer::proto::packet::decode(&buf[..len]) {
                 match hdr.kind {
                     Kind::Control => {
-                        println!("(setup) Got CONTROL {} bytes from {}", payload.len(), src);
+                        println!(
+                            "(setup) Got {MSG_CONTROL} {} bytes from {src}",
+                            payload.len()
+                        );
 
                         //temporarly: if payload is text, process as before
                         if let Ok(s) = std::str::from_utf8(payload) {
-                            println!("(setup) CONTROL payload: {}", s.trim());
+                            println!("(setup) {MSG_CONTROL} payload: {}", s.trim());
+                            try_handle_welcome(s, &channel_id, &my_peer_id);
                             if &src == server_socketaddr {
-                                if s.lines().any(|l| l.trim_start().starts_with("MODE ")) {
+                                if s.lines()
+                                    .any(|l| l.trim_start().starts_with(&format!("{MSG_MODE} ")))
+                                {
                                     *saw_mode = true;
                                 }
 
@@ -247,7 +247,10 @@ fn handle_recv_result(
             }
             let resp = String::from_utf8_lossy(&buf[..len]).to_string();
             if &src == server_socketaddr {
-                if resp.lines().any(|l| l.trim_start().starts_with("MODE ")) {
+                if resp
+                    .lines()
+                    .any(|l| l.trim_start().starts_with(&format!("{MSG_MODE} ")))
+                {
                     *saw_mode = true;
                 }
 
@@ -313,6 +316,8 @@ fn server_responses_during_setup(
     signaling_addr: &str,
     punch_sync: &PunchSync,
     relay_sync: &RelaySync,
+    channel_id: &Arc<AtomicU32>,
+    my_peer_id: &Arc<AtomicU32>,
 ) {
     let mut buf = [0u8; 2048];
     let setup_deadline = Instant::now() + Duration::from_millis(SETUP_DEADLINE_MS);
@@ -334,6 +339,8 @@ fn server_responses_during_setup(
             &mut saw_mode,
             punch_sync,
             relay_sync,
+            &channel_id,
+            &my_peer_id,
         ) {
             break;
         }
@@ -351,6 +358,8 @@ fn main_loop(
     punch_sync: &PunchSync,
     relay_sync: &RelaySync,
     send_via_server: &Arc<AtomicBool>,
+    channel_id: &Arc<AtomicU32>,
+    my_peer_id: &Arc<AtomicU32>,
 ) -> std::io::Result<()> {
     let mut buf = [0u8; 2048];
 
@@ -361,10 +370,11 @@ fn main_loop(
                 if let Some((hdr, payload)) = od_nat_piercer::proto::packet::decode(&buf[..len]) {
                     match hdr.kind {
                         Kind::Control => {
-                            println!("Got CONTROL {} bytes from {}", payload.len(), src);
-                            //temporarly: if payload is text, parse it as before
+                            println!("Got {MSG_CONTROL} {} bytes from {src}", payload.len());
                             if let Ok(s) = std::str::from_utf8(payload) {
-                                println!("CONTROL payload: {}", s.trim());
+                                println!("{MSG_CONTROL} payload: {}", s.trim());
+                                try_handle_welcome(s, &channel_id, &my_peer_id);
+
                                 process_incoming_message(
                                     socket,
                                     s,
@@ -442,6 +452,9 @@ fn main() -> std::io::Result<()> {
 
     let socket = setup_socket(local_port);
 
+    let my_peer_id = Arc::new(AtomicU32::new(0));
+    let channel_id = Arc::new(AtomicU32::new(0));
+
     // NAT detection before CONNECT
     let my_nat = detect_nat_kind(&socket, &signaling_ip);
     println!("My NAT kind: {:?}", my_nat);
@@ -462,8 +475,6 @@ fn main() -> std::io::Result<()> {
         &user,
         my_nat,
     );
-
-    send_control_test(&socket, &signaling_addr);
 
     let peers: Vec<PeerInfo> = Vec::new();
     let peers = Arc::new(Mutex::new(peers));
@@ -503,6 +514,8 @@ fn main() -> std::io::Result<()> {
         &signaling_addr,
         &punch_sync,
         &relay_sync,
+        &channel_id,
+        &my_peer_id,
     );
 
     // start punching ONLY if NAT is not symmetric
@@ -549,5 +562,7 @@ fn main() -> std::io::Result<()> {
         &punch_sync,
         &relay_sync,
         &send_via_server,
+        &channel_id,
+        &my_peer_id,
     )
 }

--- a/src/client/handlers.rs
+++ b/src/client/handlers.rs
@@ -10,16 +10,16 @@ use std::{
     str::FromStr,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicU32, Ordering},
+        atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
     },
     time::Instant,
 };
 
-pub fn try_handle_welcome(s: &str, channel_id: &Arc<AtomicU32>, my_peer_id: &Arc<AtomicU32>) {
+pub fn try_handle_welcome(s: &str, channel_id: &Arc<AtomicU64>, my_peer_id: &Arc<AtomicU32>) {
     for line in s.lines() {
         let parts: Vec<&str> = line.split_whitespace().collect();
         if parts.len() == 3 && parts[0] == MSG_WELCOME {
-            if let (Ok(cid), Ok(pid)) = (parts[1].parse::<u32>(), parts[2].parse::<u32>()) {
+            if let (Ok(cid), Ok(pid)) = (parts[1].parse::<u64>(), parts[2].parse::<u32>()) {
                 channel_id.store(cid, Ordering::Release);
                 my_peer_id.store(pid, Ordering::Release);
                 println!("{MSG_WELCOME} received: channel_id={cid}, my_peer_id={pid}");

--- a/src/client/handlers.rs
+++ b/src/client/handlers.rs
@@ -1,11 +1,32 @@
-use crate::client::structures::{NatKind, PeerInfo};
+use crate::{
+    client::structures::{NatKind, PeerInfo},
+    proto::control_text::{
+        MSG_DATA, MSG_DIRECT, MSG_HOLE_PUNCH, MSG_MODE, MSG_NAT_SEEN, MSG_PING, MSG_PONG,
+        MSG_RELAY, MSG_SERVER_RELAY, MSG_USER_LEFT, MSG_WELCOME,
+    },
+};
 use std::{
     net::{SocketAddr, UdpSocket},
     str::FromStr,
-    sync::atomic::{AtomicBool, Ordering},
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU32, Ordering},
+    },
     time::Instant,
 };
+
+pub fn try_handle_welcome(s: &str, channel_id: &Arc<AtomicU32>, my_peer_id: &Arc<AtomicU32>) {
+    for line in s.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() == 3 && parts[0] == MSG_WELCOME {
+            if let (Ok(cid), Ok(pid)) = (parts[1].parse::<u32>(), parts[2].parse::<u32>()) {
+                channel_id.store(cid, Ordering::Release);
+                my_peer_id.store(pid, Ordering::Release);
+                println!("{MSG_WELCOME} received: channel_id={cid}, my_peer_id={pid}");
+            }
+        }
+    }
+}
 
 fn handle_mode_relay(is_relay: &Arc<Mutex<bool>>) {
     let mut r = is_relay.lock().unwrap();
@@ -48,11 +69,11 @@ fn handle_user_left(parts: &[&str], peers: &Arc<Mutex<Vec<PeerInfo>>>) {
 }
 
 fn handle_unrecognized_command(line: &str) {
-    if line != "PING" && line != "HOLE_PUNCH" {
+    if line != MSG_PING && line != MSG_HOLE_PUNCH {
         return;
     }
 
-    if line.starts_with("NAT_SEEN ") {
+    if line.starts_with(&format!("{MSG_NAT_SEEN} ")) {
         return;
     }
 
@@ -72,10 +93,10 @@ pub fn handle_mode_line(
     }
 
     match parts[0] {
-        "MODE" if parts.len() >= 2 => match parts[1] {
-            "RELAY" => handle_mode_relay(is_relay),
+        MSG_MODE if parts.len() >= 2 => match parts[1] {
+            MSG_RELAY => handle_mode_relay(is_relay),
 
-            "SERVER_RELAY" => {
+            MSG_SERVER_RELAY => {
                 if parts.len() >= 3 {
                     let username = parts[2];
 
@@ -106,24 +127,24 @@ pub fn handle_mode_line(
                 }
             }
 
-            "DIRECT" if parts.len() >= 4 => handle_mode_direct(&parts, peers, me),
+            MSG_DIRECT if parts.len() >= 4 => handle_mode_direct(&parts, peers, me),
             _ => handle_unrecognized_command(line),
         },
-        "USER_LEFT" if parts.len() >= 2 => handle_user_left(&parts, peers),
+        MSG_USER_LEFT if parts.len() >= 2 => handle_user_left(&parts, peers),
         _ => handle_unrecognized_command(line),
     }
 }
 
 pub fn handle_ping(socket: &UdpSocket, src: std::net::SocketAddr) {
-    let _ = socket.send_to(b"PONG", src);
-    println!("Received PING from {}, sent PONG", src);
+    let _ = socket.send_to(MSG_PONG.as_bytes(), src);
+    println!("Received {MSG_PING} from {src}, sent {MSG_PONG}");
 }
 
 pub fn handle_pong(peers: &Arc<Mutex<Vec<PeerInfo>>>, src: std::net::SocketAddr) {
     let mut peers_guard = peers.lock().unwrap();
     if let Some(peer) = peers_guard.iter_mut().find(|p| p.addr == src) {
         peer.last_pong = Instant::now();
-        println!("Received PONG from {}", peer.username);
+        println!("Received {MSG_PONG} from {}", peer.username);
     }
 }
 
@@ -172,7 +193,7 @@ pub fn handle_data_message(
     channel_has_server_relays: &Arc<AtomicBool>,
     signaling_addr: &str,
 ) {
-    if line.starts_with("DATA ") {
+    if line.starts_with(&format!("{MSG_DATA} ")) {
         let parts: Vec<&str> = line.splitn(3, ' ').collect();
         if parts.len() >= 3 {
             let sender = parts[1];
@@ -229,11 +250,11 @@ pub fn process_incoming_message(
             continue;
         }
         match line {
-            "PING" => handle_ping(socket, src),
-            "PONG" => handle_pong(peers, src),
-            "HOLE_PUNCH" => handle_hole_punch(peers, src),
+            MSG_PING => handle_ping(socket, src),
+            MSG_PONG => handle_pong(peers, src),
+            MSG_HOLE_PUNCH => handle_hole_punch(peers, src),
             _ => {
-                if line.starts_with("DATA ") {
+                if line.starts_with(&format!("{MSG_DATA} ")) {
                     handle_data_message(
                         socket,
                         line,

--- a/src/client/networking.rs
+++ b/src/client/networking.rs
@@ -6,6 +6,10 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::client::structures::{NatKind, PeerInfo, PunchSync, RelaySync};
+use crate::proto::control_text::{
+    MSG_DATA, MSG_HB, MSG_HOLE_PUNCH, MSG_NAT_PROBE, MSG_NAT_SEEN, MSG_PEER_TIMEOUT, MSG_PING,
+    MSG_REQUEST_RELAY, NAT_TYPE_CONE, NAT_TYPE_SYMMETRIC,
+};
 
 const PUNCH_INITIAL_SLEEP_MS: u64 = 150; //initial sleep between punches
 const PUNCH_MAX_SLEEP_MS: u64 = 1500; // max sleep value between punches
@@ -20,8 +24,8 @@ pub fn detect_nat_kind(socket: &UdpSocket, signaling_ip: &str) -> NatKind {
     let addr1 = format!("{}:2131", signaling_ip);
     let addr2 = format!("{}:2132", signaling_ip);
 
-    let _ = socket.send_to(b"NAT_PROBE 1\n", &addr1);
-    let _ = socket.send_to(b"NAT_PROBE 2\n", &addr2);
+    let _ = socket.send_to(format!("{MSG_NAT_PROBE} 1\n").as_bytes(), &addr1);
+    let _ = socket.send_to(format!("{MSG_NAT_PROBE} 2\n").as_bytes(), &addr2);
 
     let mut seen = Vec::new();
     let mut buf = [0u8; 256];
@@ -31,7 +35,7 @@ pub fn detect_nat_kind(socket: &UdpSocket, signaling_ip: &str) -> NatKind {
         match socket.recv_from(&mut buf) {
             Ok((len, _src)) => {
                 let msg = String::from_utf8_lossy(&buf[..len]).to_string();
-                if msg.starts_with("NAT_SEEN ") {
+                if msg.starts_with(&format!("{MSG_NAT_SEEN} ")) {
                     if let Some(addr_str) = msg.split_whitespace().nth(1) {
                         if let Ok(observed) = addr_str.parse::<std::net::SocketAddr>() {
                             seen.push(observed);
@@ -60,10 +64,10 @@ pub fn detect_nat_kind(socket: &UdpSocket, signaling_ip: &str) -> NatKind {
     }
 
     if a.port() == b.port() {
-        println!("NAT detection: CONE(same addr on both ports): {}", a);
+        println!("NAT detection: {NAT_TYPE_CONE} (same addr on both ports): {a}",);
         NatKind::Cone
     } else {
-        println!("NAT detection: SYMMETRIC (different ports): {} vs {}", a, b);
+        println!("NAT detection: {NAT_TYPE_SYMMETRIC} (different ports): {a} vs {b}",);
         NatKind::Symmetric
     }
 }
@@ -76,7 +80,7 @@ fn heartbeat_loop(
     signaling_addr: String,
 ) {
     loop {
-        let hb = format!("HB {} {} {}", server_id, channel, user);
+        let hb = format!("{MSG_HB} {server_id} {channel} {user}");
         let _ = socket.send_to(hb.as_bytes(), &signaling_addr);
         thread::sleep(Duration::from_secs(HEARTBEAT_SLEEP_SEC));
     }
@@ -118,7 +122,7 @@ fn hole_punching_loop(socket: UdpSocket, peers: Arc<Mutex<Vec<PeerInfo>>>, sync:
                     continue; //don't punch server-relayed peers
                 }
 
-                if let Err(e) = socket.send_to(b"HOLE_PUNCH", p.addr) {
+                if let Err(e) = socket.send_to(MSG_HOLE_PUNCH.as_bytes(), p.addr) {
                     eprintln!("Failed to send punch to {}: {}", p.addr, e);
                 } else {
                     println!("Sent UDP punch to {} ({})", p.username, p.addr);
@@ -159,7 +163,11 @@ fn handle_peer_timeout(
 ) {
     println!("Peer {} timeout - reporting to server", peer.username);
     let _ = socket.send_to(
-        format!("PEER_TIMEOUT {} {} {}", server_id, channel, peer.username).as_bytes(),
+        format!(
+            "{MSG_PEER_TIMEOUT} {} {} {}",
+            server_id, channel, peer.username
+        )
+        .as_bytes(),
         &signaling_addr,
     );
 }
@@ -193,7 +201,7 @@ fn relay_main_loop(
                     handle_peer_timeout(socket, server_id, channel, peer, signaling_addr);
                     to_remove.push(i);
                 } else {
-                    if let Err(e) = socket.send_to(b"PING", peer.addr) {
+                    if let Err(e) = socket.send_to(MSG_PING.as_bytes(), peer.addr) {
                         eprintln!("Failed to send PING to {}: {}", peer.addr, e);
                     }
 
@@ -208,7 +216,7 @@ fn relay_main_loop(
                         peer.relay_requested = true;
                         let _ = socket.send_to(
                             format!(
-                                "REQUEST_RELAY {} {} {}\n",
+                                "{MSG_REQUEST_RELAY} {} {} {}\n",
                                 server_id, channel, peer.username
                             )
                             .as_bytes(),
@@ -312,11 +320,11 @@ fn handle_user_message(
     is_relay: &Arc<Mutex<bool>>,
     channel_has_server_relays: &Arc<AtomicBool>,
 ) {
-    let payload = format!("DATA {} {}\n", username, message);
+    let payload = format!("{MSG_DATA} {username} {message}\n");
 
     // if i am simmetric, send via server
     if send_via_server {
-        println!("Sending DATA via server relay: {}", message);
+        println!("Sending {MSG_DATA} via server relay: {message}");
         let _ = socket.send_to(payload.as_bytes(), signaling_addr);
         return;
     }

--- a/src/proto/control_text.rs
+++ b/src/proto/control_text.rs
@@ -1,0 +1,26 @@
+pub const MSG_WELCOME: &str = "WELCOME";
+pub const MSG_CONTROL: &str = "CONTROL";
+
+pub const MSG_CONNECT: &str = "CONNECT";
+pub const MSG_DISCONNECT: &str = "DISCONNECT";
+pub const MSG_HB: &str = "HB";
+pub const MSG_NAT_PROBE: &str = "NAT_PROBE";
+pub const MSG_NAT_SEEN: &str = "NAT_SEEN";
+pub const MSG_PEER_TIMEOUT: &str = "PEER_TIMEOUT";
+pub const MSG_REQUEST_RELAY: &str = "REQUEST_RELAY";
+pub const MSG_DATA: &str = "DATA";
+
+pub const NAT_TYPE_SYMMETRIC: &str = "SYMMETRIC";
+pub const NAT_TYPE_CONE: &str = "CONE";
+pub const NAT_TYPE_PUBLIC: &str = "PUBLIC";
+pub const NAT_TYPE_UNKNOWN: &str = "UNKNOWN";
+
+pub const MSG_MODE: &str = "MODE";
+pub const MSG_RELAY: &str = "RELAY";
+pub const MSG_DIRECT: &str = "DIRECT";
+pub const MSG_SERVER_RELAY: &str = "SERVER_RELAY";
+
+pub const MSG_USER_LEFT: &str = "USER_LEFT";
+pub const MSG_PING: &str = "PING";
+pub const MSG_PONG: &str = "PONG";
+pub const MSG_HOLE_PUNCH: &str = "HOLE_PUNCH";

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,1 +1,2 @@
+pub mod control_text;
 pub mod packet;

--- a/src/proto/packet.rs
+++ b/src/proto/packet.rs
@@ -34,6 +34,24 @@ pub struct Header {
 
 pub const HEADER_LEN: usize = 26;
 
+impl Header {
+    pub fn control(channel_id: u32, src_peer_id: u32, dst_peer_id: u32, payload_len: u16) -> Self {
+        Self {
+            kind: Kind::Control,
+            flags: 0,
+            channel_id,
+            src_peer_id,
+            dst_peer_id,
+            stream_id: 0,
+            payload_len,
+        }
+    }
+
+    pub fn welcome(channel_id: u32, dst_peer_id: u32, payload_len: u16) -> Self {
+        Self::control(channel_id, 0, dst_peer_id, payload_len)
+    }
+}
+
 pub fn encode(h: Header, payload: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(HEADER_LEN + payload.len());
     out.extend_from_slice(&MAGIC);

--- a/src/proto/packet.rs
+++ b/src/proto/packet.rs
@@ -25,17 +25,17 @@ impl Kind {
 pub struct Header {
     pub kind: Kind,
     pub flags: u16,
-    pub channel_id: u32,
+    pub channel_id: u64,
     pub src_peer_id: u32,
     pub dst_peer_id: u32,
     pub stream_id: u32,
     pub payload_len: u16,
 }
 
-pub const HEADER_LEN: usize = 26;
+pub const HEADER_LEN: usize = 30;
 
 impl Header {
-    pub fn control(channel_id: u32, src_peer_id: u32, dst_peer_id: u32, payload_len: u16) -> Self {
+    pub fn control(channel_id: u64, src_peer_id: u32, dst_peer_id: u32, payload_len: u16) -> Self {
         Self {
             kind: Kind::Control,
             flags: 0,
@@ -47,7 +47,7 @@ impl Header {
         }
     }
 
-    pub fn welcome(channel_id: u32, dst_peer_id: u32, payload_len: u16) -> Self {
+    pub fn welcome(channel_id: u64, dst_peer_id: u32, payload_len: u16) -> Self {
         Self::control(channel_id, 0, dst_peer_id, payload_len)
     }
 }
@@ -80,11 +80,11 @@ pub fn decode(buf: &[u8]) -> Option<(Header, &[u8])> {
     }
     let kind = Kind::from_u8(buf[5])?;
     let flags = u16::from_le_bytes([buf[6], buf[7]]);
-    let channel_id = u32::from_le_bytes(buf[8..12].try_into().ok()?);
-    let src_peer_id = u32::from_le_bytes(buf[12..16].try_into().ok()?);
-    let dst_peer_id = u32::from_le_bytes(buf[16..20].try_into().ok()?);
-    let stream_id = u32::from_le_bytes(buf[20..24].try_into().ok()?);
-    let payload_len = u16::from_le_bytes([buf[24], buf[25]]);
+    let channel_id = u64::from_le_bytes(buf[8..16].try_into().ok()?);
+    let src_peer_id = u32::from_le_bytes(buf[16..20].try_into().ok()?);
+    let dst_peer_id = u32::from_le_bytes(buf[20..24].try_into().ok()?);
+    let stream_id = u32::from_le_bytes(buf[24..28].try_into().ok()?);
+    let payload_len = u16::from_le_bytes([buf[28], buf[29]]);
     let payload_len = payload_len as usize;
 
     let payload_start = HEADER_LEN;
@@ -116,7 +116,7 @@ mod tests {
         let h = Header {
             kind: Kind::Control,
             flags: 0x1224,
-            channel_id: 1,
+            channel_id: 1u64,
             src_peer_id: 2,
             dst_peer_id: BROADCAST,
             stream_id: 3,
@@ -129,6 +129,7 @@ mod tests {
         assert_eq!(h2.flags, h.flags);
         assert_eq!(h2.channel_id, h.channel_id);
         assert_eq!(h2.src_peer_id, h.src_peer_id);
+        assert_eq!(h2.dst_peer_id, h.dst_peer_id);
         assert_eq!(h2.stream_id, h.stream_id);
         assert_eq!(p2, payload);
     }

--- a/src/signaling/handlers/connect.rs
+++ b/src/signaling/handlers/connect.rs
@@ -1,4 +1,12 @@
-use crate::signaling::structures::{NatKind, ServerMap};
+use crate::{
+    proto::control_text::{MSG_WELCOME, NAT_TYPE_CONE, NAT_TYPE_PUBLIC, NAT_TYPE_SYMMETRIC},
+    signaling::{
+        handlers::utils::make_channel_id,
+        structures::{NatKind, ServerMap},
+    },
+};
+
+use crate::proto::packet::{self, Header, Kind};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{net::UdpSocket, sync::Mutex};
 
@@ -6,6 +14,22 @@ use super::{
     notifications::handle_connect_notifications,
     utils::{add_new_user, remove_user_from_other_channels, update_existing_user},
 };
+
+async fn send_welcome(socket: &Arc<UdpSocket>, dst: SocketAddr, channel_id: u32, peer_id: u32) {
+    let payload = format!("{MSG_WELCOME} to cid:{channel_id} with pid:{peer_id}\n");
+    let hdr = Header {
+        kind: Kind::Control,
+        flags: 0,
+        channel_id,
+        src_peer_id: 0, //for now
+        dst_peer_id: peer_id,
+        stream_id: 0,
+        payload_len: payload.len() as u16,
+    };
+
+    let pkt = packet::encode(hdr, payload.as_bytes());
+    let _ = socket.send_to(&pkt, dst).await;
+}
 
 pub async fn handle_connect_message(
     parts: &[&str],
@@ -20,16 +44,16 @@ pub async fn handle_connect_message(
 
     let nat_kind = if parts.len() >= 5 {
         match parts[4] {
-            "SYMMETRIC" => NatKind::Symmetric,
-            "CONE" => NatKind::Cone,
-            "PUBLIC" => NatKind::Public,
+            NAT_TYPE_SYMMETRIC => NatKind::Symmetric,
+            NAT_TYPE_CONE => NatKind::Cone,
+            NAT_TYPE_PUBLIC => NatKind::Public,
             _ => NatKind::Unknown,
         }
     } else {
         NatKind::Unknown
     };
 
-    let (users_to_notify, is_new_user) = {
+    let (users_to_notify, is_new_user, peer_id, channel_id) = {
         let mut st = state.lock().await;
 
         remove_user_from_other_channels(&mut st, &server_id, &channel_name, &user_name, src_addr)
@@ -38,14 +62,24 @@ pub async fn handle_connect_message(
         let channels = st.entry(server_id.clone()).or_default();
         let channel = channels.entry(channel_name.clone()).or_default();
 
-        if let Some(result) = update_existing_user(channel, &user_name, src_addr).await {
-            result
+        if channel.channel_id == 0 {
+            channel.channel_id = make_channel_id(&server_id, &channel_name);
+        }
+
+        let channel_id = channel.channel_id;
+
+        if let Some((updated_channel, is_new, peer_id)) =
+            update_existing_user(channel, &user_name, src_addr).await
+        {
+            (updated_channel, is_new, peer_id, channel_id)
         } else {
-            let update_channel =
+            let (update_channel, peer_id) =
                 add_new_user(channel, &user_name, src_addr, &socket, nat_kind).await;
-            (update_channel, true)
+            (update_channel, true, peer_id, channel_id)
         }
     };
+
+    send_welcome(&socket, src_addr, channel_id, peer_id).await;
 
     if !is_new_user {
         return;

--- a/src/signaling/handlers/connect.rs
+++ b/src/signaling/handlers/connect.rs
@@ -17,15 +17,7 @@ use super::{
 
 async fn send_welcome(socket: &Arc<UdpSocket>, dst: SocketAddr, channel_id: u32, peer_id: u32) {
     let payload = format!("{MSG_WELCOME} to cid:{channel_id} with pid:{peer_id}\n");
-    let hdr = Header {
-        kind: Kind::Control,
-        flags: 0,
-        channel_id,
-        src_peer_id: 0, //for now
-        dst_peer_id: peer_id,
-        stream_id: 0,
-        payload_len: payload.len() as u16,
-    };
+    let hdr = Header::welcome(channel_id, peer_id, payload.len() as u16);
 
     let pkt = packet::encode(hdr, payload.as_bytes());
     let _ = socket.send_to(&pkt, dst).await;

--- a/src/signaling/handlers/connect.rs
+++ b/src/signaling/handlers/connect.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 
-use crate::proto::packet::{self, Header, Kind};
+use crate::proto::packet::{self, Header};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{net::UdpSocket, sync::Mutex};
 

--- a/src/signaling/handlers/connect.rs
+++ b/src/signaling/handlers/connect.rs
@@ -1,8 +1,8 @@
 use crate::{
     proto::control_text::{MSG_WELCOME, NAT_TYPE_CONE, NAT_TYPE_PUBLIC, NAT_TYPE_SYMMETRIC},
     signaling::{
-        handlers::utils::make_channel_id,
         structures::{NatKind, ServerMap},
+        utils::generate_channel_id,
     },
 };
 
@@ -15,7 +15,7 @@ use super::{
     utils::{add_new_user, remove_user_from_other_channels, update_existing_user},
 };
 
-async fn send_welcome(socket: &Arc<UdpSocket>, dst: SocketAddr, channel_id: u32, peer_id: u32) {
+async fn send_welcome(socket: &Arc<UdpSocket>, dst: SocketAddr, channel_id: u64, peer_id: u32) {
     let payload = format!("{MSG_WELCOME} to cid:{channel_id} with pid:{peer_id}\n");
     let hdr = Header::welcome(channel_id, peer_id, payload.len() as u16);
 
@@ -55,7 +55,7 @@ pub async fn handle_connect_message(
         let channel = channels.entry(channel_name.clone()).or_default();
 
         if channel.channel_id == 0 {
-            channel.channel_id = make_channel_id(&server_id, &channel_name);
+            channel.channel_id = generate_channel_id();
         }
 
         let channel_id = channel.channel_id;

--- a/src/signaling/handlers/message.rs
+++ b/src/signaling/handlers/message.rs
@@ -1,4 +1,7 @@
-use crate::proto::packet::{BROADCAST, Header, Kind, encode};
+use crate::proto::control_text::{
+    MSG_CONNECT, MSG_DATA, MSG_DISCONNECT, MSG_HB, MSG_NAT_PROBE, MSG_NAT_SEEN, MSG_PEER_TIMEOUT,
+    MSG_PONG, MSG_REQUEST_RELAY,
+};
 use crate::signaling::structures::ServerMap;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{net::UdpSocket, sync::Mutex};
@@ -17,61 +20,44 @@ pub async fn handle_message(
     socket: Arc<UdpSocket>,
     state: Arc<Mutex<ServerMap>>,
 ) {
-    if msg.starts_with("NAT_PROBE") {
-        let reply = format!("NAT_SEEN {}\n", src);
+    if msg.starts_with(MSG_NAT_PROBE) {
+        let reply = format!("{MSG_NAT_SEEN} {src}\n");
         let _ = socket.send_to(reply.as_bytes(), src).await;
         return;
     }
 
     let parts: Vec<&str> = msg.trim().split_whitespace().collect();
 
-    if msg.trim() == "PONG" {
+    if msg.trim() == MSG_PONG {
         handle_pong(src, state).await;
         return;
     }
 
-    if parts.len() >= 4 && parts[0] == "HB" {
+    if parts.len() >= 4 && parts[0] == MSG_HB {
         handle_heartbeat(&parts, src, state).await;
         return;
     }
 
     if parts.len() >= 1 {
         match parts[0] {
-            "CONNECT" if parts.len() >= 4 => {
+            MSG_CONNECT if parts.len() >= 4 => {
                 handle_connect_message(&parts, src, socket, state).await;
             }
 
-            "DISCONNECT" if parts.len() >= 4 => {
+            MSG_DISCONNECT if parts.len() >= 4 => {
                 handle_disconnect_message(&parts, src, socket, state).await;
             }
 
-            "PEER_TIMEOUT" if parts.len() >= 4 => {
+            MSG_PEER_TIMEOUT if parts.len() >= 4 => {
                 handle_peer_timeout(&parts, src, socket, state).await;
             }
 
-            "REQUEST_RELAY" if parts.len() >= 4 => {
+            MSG_REQUEST_RELAY if parts.len() >= 4 => {
                 handle_relay_request(&parts, src, socket, state).await;
             }
 
-            "DATA" if parts.len() >= 3 => {
+            MSG_DATA if parts.len() >= 3 => {
                 handle_data_from_client(&msg, src, socket, state).await;
-            }
-
-            "CONTROL_TEST" => {
-                println!("CONTROL_TEST from {}", src);
-
-                let payload = b"CONTROL_TEST_OK\n";
-                let hdr = Header {
-                    kind: Kind::Control,
-                    flags: 0,
-                    channel_id: 0,
-                    src_peer_id: 0,
-                    dst_peer_id: BROADCAST,
-                    stream_id: 0,
-                    payload_len: payload.len() as u16,
-                };
-                let pkt = encode(hdr, payload);
-                let _ = socket.send_to(&pkt, src).await;
             }
 
             _ => {

--- a/src/signaling/handlers/notifications.rs
+++ b/src/signaling/handlers/notifications.rs
@@ -302,7 +302,7 @@ pub async fn handle_relay_transition(
                 }
             }
         } else {
-            //nici un user eligibil -> ramane serverul ca relay, anuntam SERVER_RELAY pentru toti
+            //no eligible user -> server remains relay, announce SERVER_RELAY for all peers
             for u in &channel.users {
                 let notify = format!("{} {} {}\n", MSG_MODE, MSG_SERVER_RELAY, u.name);
                 for usr in &channel.users {

--- a/src/signaling/handlers/notifications.rs
+++ b/src/signaling/handlers/notifications.rs
@@ -1,4 +1,7 @@
-use crate::signaling::structures::{Channel, NatKind, ServerMap, User};
+use crate::{
+    proto::control_text::{MSG_DIRECT, MSG_MODE, MSG_RELAY, MSG_SERVER_RELAY, MSG_USER_LEFT},
+    signaling::structures::{Channel, NatKind, ServerMap, User},
+};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{net::UdpSocket, sync::Mutex};
 
@@ -32,7 +35,7 @@ pub async fn mark_relay_in_channel(
 
 pub async fn notify_relay_about_peers(socket: &Arc<UdpSocket>, relay_user: &User, peers: &[User]) {
     for peer in peers {
-        let msg = format!("MODE DIRECT {} {}\n", peer.name, peer.addr);
+        let msg = format!("{} {} {} {}\n", MSG_MODE, MSG_DIRECT, peer.name, peer.addr);
         if let Err(e) = socket.send_to(msg.as_bytes(), relay_user.addr).await {
             eprintln!(
                 "Failed to notify relay {} about {}: {}",
@@ -44,7 +47,10 @@ pub async fn notify_relay_about_peers(socket: &Arc<UdpSocket>, relay_user: &User
 
 pub async fn notify_peers_about_relay(socket: &Arc<UdpSocket>, relay_user: &User, peers: &[User]) {
     for peer in peers {
-        let msg = format!("MODE DIRECT {} {}\n", relay_user.name, relay_user.addr);
+        let msg = format!(
+            "{} {} {} {}\n",
+            MSG_MODE, MSG_DIRECT, relay_user.name, relay_user.addr
+        );
         if let Err(e) = socket.send_to(msg.as_bytes(), peer.addr).await {
             eprintln!(
                 "Failed to notify {} about new relay{}: {}",
@@ -55,7 +61,7 @@ pub async fn notify_peers_about_relay(socket: &Arc<UdpSocket>, relay_user: &User
 }
 
 pub async fn send_relay_mode_to_relay(socket: &Arc<UdpSocket>, relay_user: &User) {
-    let reply = "MODE RELAY\n";
+    let reply = format!("{MSG_MODE} {MSG_RELAY}\n");
     if let Err(e) = socket.send_to(reply.as_bytes(), relay_user.addr).await {
         eprintln!("Failed to send RELAY mode to {}: {}", relay_user.name, e);
     }
@@ -69,12 +75,13 @@ pub async fn notify_existing_users_about_new_user(
 ) {
     for user in users.iter() {
         if user.addr != new_user_addr {
-            let msg_to_existing = format!("MODE DIRECT {} {}\n", new_user_name, new_user_addr);
+            let msg_to_existing =
+                format!("{MSG_MODE} {MSG_DIRECT} {new_user_name} {new_user_addr}\n");
             if let Err(e) = socket.send_to(msg_to_existing.as_bytes(), user.addr).await {
                 eprintln!("Failed to notify {}: {}", user.name, e);
             }
 
-            let msg_to_new = format!("MODE DIRECT {} {}\n", user.name, user.addr);
+            let msg_to_new = format!("{} {} {} {}\n", MSG_MODE, MSG_DIRECT, user.name, user.addr);
             if let Err(e) = socket.send_to(msg_to_new.as_bytes(), new_user_addr).await {
                 eprintln!("Failed to notify new user: {}", e);
             }
@@ -84,7 +91,10 @@ pub async fn notify_existing_users_about_new_user(
 
 pub async fn promote_new_relay(socket: &Arc<UdpSocket>, new_relay: &User) {
     if let Err(e) = socket
-        .send_to("MODE RELAY\n".as_bytes(), new_relay.addr)
+        .send_to(
+            format!("{MSG_MODE} {MSG_RELAY}\n").as_bytes(),
+            new_relay.addr,
+        )
         .await
     {
         eprintln!(
@@ -96,7 +106,7 @@ pub async fn promote_new_relay(socket: &Arc<UdpSocket>, new_relay: &User) {
 
 pub async fn notify_lone_user(socket: &Arc<UdpSocket>, lone_user_addr: Option<SocketAddr>) {
     if let Some(lone_user_addr) = lone_user_addr {
-        let reply = "MODE RELAY\n";
+        let reply = format!("{MSG_MODE} {MSG_RELAY}\n");
         if let Err(e) = socket.send_to(reply.as_bytes(), lone_user_addr).await {
             eprintln!("Failed to notify lone user: {}", e);
         }
@@ -109,7 +119,10 @@ pub async fn notify_peers_about_new_relay(
     peers: &[User],
 ) {
     for user in peers {
-        let msg = format!("MODE DIRECT {} {}\n", new_relay.name, new_relay.addr);
+        let msg = format!(
+            "{} {} {} {}\n",
+            MSG_MODE, MSG_DIRECT, new_relay.name, new_relay.addr
+        );
         if let Err(e) = socket.send_to(msg.as_bytes(), user.addr).await {
             eprintln!("Failed to notify {} about new relay: {}", user.name, e);
         }
@@ -122,7 +135,7 @@ pub async fn notify_new_relay_about_peers(
     peers: &[User],
 ) {
     for user in peers {
-        let msg = format!("MODE DIRECT {} {}\n", user.name, user.addr);
+        let msg = format!("{} {} {} {}\n", MSG_MODE, MSG_DIRECT, user.name, user.addr);
         if let Err(e) = socket.send_to(msg.as_bytes(), new_relay.addr).await {
             eprintln!(
                 "Failed to notify {} about connected users: {}",
@@ -140,7 +153,8 @@ pub async fn notify_all_about_departure(
 ) {
     for user in remaining_users {
         let departure_msg = format!(
-            "USER_LEFT {} {}\n",
+            "{} {} {}\n",
+            MSG_USER_LEFT,
             user_name,
             leaving_user_addr
                 .map(|a| a.to_string())
@@ -208,7 +222,7 @@ pub async fn handle_multiple_users_scenario(
 
         // 5) SYMMETRIC peers: only get MODE SERVER_RELAY
         for symmetric in symmetric_peers.iter() {
-            let msg = format!("MODE SERVER_RELAY {}\n", symmetric.name);
+            let msg = format!("{} {} {}\n", MSG_MODE, MSG_SERVER_RELAY, symmetric.name);
 
             //1) send to symmetric user (to send via server)
             let _ = socket.send_to(msg.as_bytes(), symmetric.addr).await;
@@ -222,7 +236,7 @@ pub async fn handle_multiple_users_scenario(
         // no eligible user -> no user gets promoted to relay, let server as relay
         // announce that server will be relay for every user in the channel
         for u in &users_to_notify.users {
-            let notify = format!("MODE SERVER_RELAY {}\n", u.name);
+            let notify = format!("{} {} {}\n", MSG_MODE, MSG_SERVER_RELAY, u.name);
             for usr in &users_to_notify.users {
                 let _ = socket.send_to(notify.as_bytes(), usr.addr).await;
             }
@@ -290,7 +304,7 @@ pub async fn handle_relay_transition(
         } else {
             //nici un user eligibil -> ramane serverul ca relay, anuntam SERVER_RELAY pentru toti
             for u in &channel.users {
-                let notify = format!("MODE SERVER_RELAY {}\n", u.name);
+                let notify = format!("{} {} {}\n", MSG_MODE, MSG_SERVER_RELAY, u.name);
                 for usr in &channel.users {
                     let _ = socket.send_to(notify.as_bytes(), usr.addr).await;
                 }
@@ -358,7 +372,7 @@ pub async fn handle_peer_timeout(
         for u in channel.users {
             let _ = socket
                 .send_to(
-                    format!("USER_LEFT {} 0.0.0.0:0\n", peer_user).as_bytes(),
+                    format!("{MSG_USER_LEFT} {peer_user} 0.0.0.0:0\n").as_bytes(),
                     u.addr,
                 )
                 .await;

--- a/src/signaling/handlers/request_relay.rs
+++ b/src/signaling/handlers/request_relay.rs
@@ -1,4 +1,7 @@
-use crate::signaling::structures::ServerMap;
+use crate::{
+    proto::control_text::{MSG_MODE, MSG_SERVER_RELAY},
+    signaling::structures::ServerMap,
+};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{net::UdpSocket, sync::Mutex};
 
@@ -24,7 +27,7 @@ pub async fn handle_relay_request(
                 user.needs_server_relay = true;
             }
             // notify all users that the server will forward for the user that needs a relay
-            let notify = format!("MODE SERVER_RELAY {}\n", username);
+            let notify = format!("{MSG_MODE} {MSG_SERVER_RELAY} {username}\n");
             for u in channel.users.iter() {
                 let _ = socket.send_to(notify.as_bytes(), u.addr).await;
             }

--- a/src/signaling/handlers/utils.rs
+++ b/src/signaling/handlers/utils.rs
@@ -2,21 +2,8 @@ use crate::{
     proto::control_text::{MSG_MODE, MSG_RELAY, MSG_SERVER_RELAY},
     signaling::structures::{Channel, NatKind, ServerMap, User},
 };
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-    net::SocketAddr,
-    sync::Arc,
-    time::Instant,
-};
+use std::{net::SocketAddr, sync::Arc, time::Instant};
 use tokio::{net::UdpSocket, sync::Mutex};
-
-pub fn make_channel_id(server_id: &str, channel_name: &str) -> u32 {
-    let mut h = DefaultHasher::new();
-    server_id.hash(&mut h);
-    channel_name.hash(&mut h);
-    (h.finish() & 0xFFFF_FFFF) as u32
-}
 
 pub async fn get_remaining_users(
     state: &Arc<Mutex<ServerMap>>,

--- a/src/signaling/handlers/utils.rs
+++ b/src/signaling/handlers/utils.rs
@@ -116,11 +116,9 @@ pub async fn add_new_user(
     let peer_id = channel.next_peer_id;
     channel.next_peer_id += 1;
 
-    //Create and add new user
     let new_user = create_new_user(user_name, src_addr, nat_kind, peer_id).await;
     channel.users.push(new_user);
 
-    //Handle lone user scenario
     handle_lone_user_scenario(channel, socket).await;
 
     println!("User {} joined from {}", user_name, src_addr);
@@ -234,130 +232,5 @@ pub async fn remove_user_from_other_channels(
             ch.users
                 .retain(|u| !(u.name == user_name && u.addr == src_addr));
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn make_channel_id_is_stable_for_same_input() {
-        let a = make_channel_id("server1", "channel1");
-        let b = make_channel_id("server1", "channel1");
-        assert_eq!(a, b);
-    }
-
-    #[test]
-    fn make_channel_id_differs_for_different_channels() {
-        let a = make_channel_id("server1", "channel1");
-        let b = make_channel_id("server1", "channel2");
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn make_channel_id_differs_for_different_servers() {
-        let a = make_channel_id("server1", "channel1");
-        let b = make_channel_id("server2", "channel1");
-        assert_ne!(a, b);
-    }
-
-    #[tokio::test]
-    async fn create_new_user_sets_fields_correctly() {
-        let addr: std::net::SocketAddr = "127.0.0.1:5000".parse().unwrap();
-
-        let user = create_new_user("name", addr, NatKind::Cone, 7).await;
-
-        assert_eq!(user.name, "name");
-        assert_eq!(user.addr, addr);
-        assert_eq!(user.peer_id, 7);
-        assert!(!user.needs_server_relay);
-        assert_eq!(user.nat_kind, NatKind::Cone);
-    }
-
-    #[tokio::test]
-    async fn create_new_user_marks_symmetric_as_server_relay() {
-        let addr: std::net::SocketAddr = "127.0.0.1:5000".parse().unwrap();
-
-        let user = create_new_user("name", addr, NatKind::Symmetric, 9).await;
-
-        assert_eq!(user.peer_id, 9);
-        assert!(user.needs_server_relay);
-        assert_eq!(user.nat_kind, NatKind::Symmetric);
-    }
-
-    #[tokio::test]
-    async fn add_new_user_assigns_incrementing_peer_ids() {
-        let mut channel = Channel {
-            channel_id: 123,
-            next_peer_id: 1,
-            users: Vec::new(),
-            relay: None,
-        };
-
-        let socket = Arc::new(tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap());
-
-        let addr1: std::net::SocketAddr = "127.0.0.1:6001".parse().unwrap();
-        let (updated_channel, peer_id1) =
-            add_new_user(&mut channel, "name1", addr1, &socket, NatKind::Cone).await;
-
-        assert_eq!(peer_id1, 1);
-        assert_eq!(updated_channel.users.len(), 1);
-        assert_eq!(updated_channel.users[0].peer_id, 1);
-        assert_eq!(updated_channel.next_peer_id, 2);
-
-        let addr2: std::net::SocketAddr = "127.0.0.1:6002".parse().unwrap();
-        let (updated_channel, peer_id2) =
-            add_new_user(&mut channel, "name2", addr2, &socket, NatKind::Cone).await;
-
-        assert_eq!(peer_id2, 2);
-        assert_eq!(updated_channel.users.len(), 2);
-        assert_eq!(updated_channel.users[1].peer_id, 2);
-        assert_eq!(updated_channel.next_peer_id, 3);
-    }
-
-    #[tokio::test]
-    async fn update_existing_user_returns_existing_peer_id() {
-        let addr: std::net::SocketAddr = "127.0.0.1:7001".parse().unwrap();
-
-        let mut channel = Channel {
-            channel_id: 123,
-            next_peer_id: 2,
-            users: vec![User {
-                peer_id: 1,
-                name: "name".to_string(),
-                addr,
-                last_pong: std::time::Instant::now(),
-                needs_server_relay: false,
-                nat_kind: NatKind::Cone,
-            }],
-            relay: None,
-        };
-
-        let result = update_existing_user(&mut channel, "name", addr).await;
-
-        assert!(result.is_some());
-
-        let (updated_channel, is_new, peer_id) = result.unwrap();
-        assert!(!is_new);
-        assert_eq!(peer_id, 1);
-        assert_eq!(updated_channel.users.len(), 1);
-        assert_eq!(updated_channel.users[0].peer_id, 1);
-    }
-
-    #[tokio::test]
-    async fn update_existing_user_returns_none_for_missing_user() {
-        let addr: std::net::SocketAddr = "127.0.0.1:7002".parse().unwrap();
-
-        let mut channel = Channel {
-            channel_id: 123,
-            next_peer_id: 1,
-            users: Vec::new(),
-            relay: None,
-        };
-
-        let result = update_existing_user(&mut channel, "name", addr).await;
-
-        assert!(result.is_none());
     }
 }

--- a/src/signaling/handlers/utils.rs
+++ b/src/signaling/handlers/utils.rs
@@ -1,6 +1,22 @@
-use crate::signaling::structures::{Channel, NatKind, ServerMap, User};
-use std::{net::SocketAddr, sync::Arc, time::Instant};
+use crate::{
+    proto::control_text::{MSG_MODE, MSG_RELAY, MSG_SERVER_RELAY},
+    signaling::structures::{Channel, NatKind, ServerMap, User},
+};
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    net::SocketAddr,
+    sync::Arc,
+    time::Instant,
+};
 use tokio::{net::UdpSocket, sync::Mutex};
+
+pub fn make_channel_id(server_id: &str, channel_name: &str) -> u32 {
+    let mut h = DefaultHasher::new();
+    server_id.hash(&mut h);
+    channel_name.hash(&mut h);
+    (h.finish() & 0xFFFF_FFFF) as u32
+}
 
 pub async fn get_remaining_users(
     state: &Arc<Mutex<ServerMap>>,
@@ -18,7 +34,7 @@ pub async fn update_existing_user(
     channel: &mut Channel,
     user_name: &str,
     src_addr: SocketAddr,
-) -> Option<(Channel, bool)> {
+) -> Option<(Channel, bool, u32)> {
     //check if user already present with same addr
     if let Some(existing) = channel
         .users
@@ -26,7 +42,8 @@ pub async fn update_existing_user(
         .find(|u| u.name == user_name && u.addr == src_addr)
     {
         existing.last_pong = Instant::now();
-        Some((channel.clone(), false))
+        let peer_id = existing.peer_id;
+        Some((channel.clone(), false, peer_id))
     } else {
         None
     }
@@ -42,8 +59,14 @@ pub async fn remove_old_user_sessions(
         .retain(|u| !(u.name == user_name && u.addr != src_addr));
 }
 
-pub async fn create_new_user(user_name: &str, src_addr: SocketAddr, nat_kind: NatKind) -> User {
+pub async fn create_new_user(
+    user_name: &str,
+    src_addr: SocketAddr,
+    nat_kind: NatKind,
+    peer_id: u32,
+) -> User {
     User {
+        peer_id,
         name: user_name.to_string(),
         addr: src_addr,
         last_pong: Instant::now(),
@@ -57,7 +80,10 @@ pub async fn handle_lone_user_scenario(channel: &mut Channel, socket: &Arc<UdpSo
         let u = &channel.users[0];
         match u.nat_kind {
             NatKind::Symmetric => {
-                let reply = format!("MODE SERVER_RELAY {}\n", channel.users[0].name);
+                let reply = format!(
+                    "{} {} {}\n",
+                    MSG_MODE, MSG_SERVER_RELAY, channel.users[0].name
+                );
                 if let Err(e) = socket.send_to(reply.as_bytes(), u.addr).await {
                     eprintln!("Failed to notify lone user about server relay: {}", e);
                 }
@@ -65,7 +91,10 @@ pub async fn handle_lone_user_scenario(channel: &mut Channel, socket: &Arc<UdpSo
             }
 
             _ => {
-                if let Err(e) = socket.send_to(b"MODE RELAY\n", u.addr).await {
+                if let Err(e) = socket
+                    .send_to(format!("{MSG_MODE} {MSG_RELAY}\n").as_bytes(), u.addr)
+                    .await
+                {
                     eprintln!("Failed to notify lone user about relay mode: {}", e);
                 }
                 channel.relay = Some(u.name.clone());
@@ -80,12 +109,15 @@ pub async fn add_new_user(
     src_addr: SocketAddr,
     socket: &Arc<UdpSocket>,
     nat_kind: NatKind,
-) -> Channel {
+) -> (Channel, u32) {
     //Remove old user sessions with same name but different address
     remove_old_user_sessions(channel, user_name, src_addr).await;
 
+    let peer_id = channel.next_peer_id;
+    channel.next_peer_id += 1;
+
     //Create and add new user
-    let new_user = create_new_user(user_name, src_addr, nat_kind).await;
+    let new_user = create_new_user(user_name, src_addr, nat_kind, peer_id).await;
     channel.users.push(new_user);
 
     //Handle lone user scenario
@@ -93,7 +125,7 @@ pub async fn add_new_user(
 
     println!("User {} joined from {}", user_name, src_addr);
 
-    channel.clone()
+    (channel.clone(), peer_id)
 }
 
 pub async fn find_and_remove_user(
@@ -202,5 +234,130 @@ pub async fn remove_user_from_other_channels(
             ch.users
                 .retain(|u| !(u.name == user_name && u.addr == src_addr));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn make_channel_id_is_stable_for_same_input() {
+        let a = make_channel_id("server1", "channel1");
+        let b = make_channel_id("server1", "channel1");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn make_channel_id_differs_for_different_channels() {
+        let a = make_channel_id("server1", "channel1");
+        let b = make_channel_id("server1", "channel2");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn make_channel_id_differs_for_different_servers() {
+        let a = make_channel_id("server1", "channel1");
+        let b = make_channel_id("server2", "channel1");
+        assert_ne!(a, b);
+    }
+
+    #[tokio::test]
+    async fn create_new_user_sets_fields_correctly() {
+        let addr: std::net::SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+        let user = create_new_user("name", addr, NatKind::Cone, 7).await;
+
+        assert_eq!(user.name, "name");
+        assert_eq!(user.addr, addr);
+        assert_eq!(user.peer_id, 7);
+        assert!(!user.needs_server_relay);
+        assert_eq!(user.nat_kind, NatKind::Cone);
+    }
+
+    #[tokio::test]
+    async fn create_new_user_marks_symmetric_as_server_relay() {
+        let addr: std::net::SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+        let user = create_new_user("name", addr, NatKind::Symmetric, 9).await;
+
+        assert_eq!(user.peer_id, 9);
+        assert!(user.needs_server_relay);
+        assert_eq!(user.nat_kind, NatKind::Symmetric);
+    }
+
+    #[tokio::test]
+    async fn add_new_user_assigns_incrementing_peer_ids() {
+        let mut channel = Channel {
+            channel_id: 123,
+            next_peer_id: 1,
+            users: Vec::new(),
+            relay: None,
+        };
+
+        let socket = Arc::new(tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap());
+
+        let addr1: std::net::SocketAddr = "127.0.0.1:6001".parse().unwrap();
+        let (updated_channel, peer_id1) =
+            add_new_user(&mut channel, "name1", addr1, &socket, NatKind::Cone).await;
+
+        assert_eq!(peer_id1, 1);
+        assert_eq!(updated_channel.users.len(), 1);
+        assert_eq!(updated_channel.users[0].peer_id, 1);
+        assert_eq!(updated_channel.next_peer_id, 2);
+
+        let addr2: std::net::SocketAddr = "127.0.0.1:6002".parse().unwrap();
+        let (updated_channel, peer_id2) =
+            add_new_user(&mut channel, "name2", addr2, &socket, NatKind::Cone).await;
+
+        assert_eq!(peer_id2, 2);
+        assert_eq!(updated_channel.users.len(), 2);
+        assert_eq!(updated_channel.users[1].peer_id, 2);
+        assert_eq!(updated_channel.next_peer_id, 3);
+    }
+
+    #[tokio::test]
+    async fn update_existing_user_returns_existing_peer_id() {
+        let addr: std::net::SocketAddr = "127.0.0.1:7001".parse().unwrap();
+
+        let mut channel = Channel {
+            channel_id: 123,
+            next_peer_id: 2,
+            users: vec![User {
+                peer_id: 1,
+                name: "name".to_string(),
+                addr,
+                last_pong: std::time::Instant::now(),
+                needs_server_relay: false,
+                nat_kind: NatKind::Cone,
+            }],
+            relay: None,
+        };
+
+        let result = update_existing_user(&mut channel, "name", addr).await;
+
+        assert!(result.is_some());
+
+        let (updated_channel, is_new, peer_id) = result.unwrap();
+        assert!(!is_new);
+        assert_eq!(peer_id, 1);
+        assert_eq!(updated_channel.users.len(), 1);
+        assert_eq!(updated_channel.users[0].peer_id, 1);
+    }
+
+    #[tokio::test]
+    async fn update_existing_user_returns_none_for_missing_user() {
+        let addr: std::net::SocketAddr = "127.0.0.1:7002".parse().unwrap();
+
+        let mut channel = Channel {
+            channel_id: 123,
+            next_peer_id: 1,
+            users: Vec::new(),
+            relay: None,
+        };
+
+        let result = update_existing_user(&mut channel, "name", addr).await;
+
+        assert!(result.is_none());
     }
 }

--- a/src/signaling/handlers/utils.rs
+++ b/src/signaling/handlers/utils.rs
@@ -59,22 +59,6 @@ pub async fn remove_old_user_sessions(
         .retain(|u| !(u.name == user_name && u.addr != src_addr));
 }
 
-pub async fn create_new_user(
-    user_name: &str,
-    src_addr: SocketAddr,
-    nat_kind: NatKind,
-    peer_id: u32,
-) -> User {
-    User {
-        peer_id,
-        name: user_name.to_string(),
-        addr: src_addr,
-        last_pong: Instant::now(),
-        needs_server_relay: matches!(nat_kind, NatKind::Symmetric),
-        nat_kind,
-    }
-}
-
 pub async fn handle_lone_user_scenario(channel: &mut Channel, socket: &Arc<UdpSocket>) {
     if channel.relay.is_none() && channel.users.len() == 1 {
         let u = &channel.users[0];
@@ -116,7 +100,7 @@ pub async fn add_new_user(
     let peer_id = channel.next_peer_id;
     channel.next_peer_id += 1;
 
-    let new_user = create_new_user(user_name, src_addr, nat_kind, peer_id).await;
+    let new_user = User::new(user_name, src_addr, nat_kind, peer_id);
     channel.users.push(new_user);
 
     handle_lone_user_scenario(channel, socket).await;

--- a/src/signaling/heartbeat.rs
+++ b/src/signaling/heartbeat.rs
@@ -1,6 +1,11 @@
-use crate::signaling::{
-    structures::{Channel, ServerMap, User},
-    utils::cleanup_and_notify_iter,
+use crate::{
+    proto::control_text::{
+        MSG_DIRECT, MSG_MODE, MSG_PING, MSG_RELAY, MSG_SERVER_RELAY, MSG_USER_LEFT,
+    },
+    signaling::{
+        structures::{Channel, ServerMap, User},
+        utils::cleanup_and_notify_iter,
+    },
 };
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::{net::UdpSocket, sync::Mutex};
@@ -23,7 +28,10 @@ fn handle_relay_timeout(
         channel.relay = Some(new_relay_user.name.clone());
 
         //1) Send MODE RELAY just to the new relay
-        notifications.push((vec![new_relay_user.addr], b"MODE RELAY\n".to_vec()));
+        notifications.push((
+            vec![new_relay_user.addr],
+            format!("{MSG_MODE} {MSG_RELAY}\n").as_bytes().to_vec(),
+        ));
 
         //2) Send to every peer: "MODE DIRECT <relay_name> <relay_addr>"
         let peers_addrs: Vec<SocketAddr> = channel
@@ -40,8 +48,8 @@ fn handle_relay_timeout(
                 .filter(|u| u.name != new_relay_user.name)
             {
                 let m = format!(
-                    "MODE DIRECT {} {}\n",
-                    new_relay_user.name, new_relay_user.addr
+                    "{} {} {} {}\n",
+                    MSG_MODE, MSG_DIRECT, new_relay_user.name, new_relay_user.addr
                 );
                 payload.extend_from_slice(m.as_bytes());
             }
@@ -55,7 +63,7 @@ fn handle_relay_timeout(
             .iter()
             .filter(|u| u.name != new_relay_user.name)
         {
-            let m = format!("MODE DIRECT {} {}\n", peer.name, peer.addr);
+            let m = format!("{} {} {} {}\n", MSG_MODE, MSG_DIRECT, peer.name, peer.addr);
             peers_to_new_msg.extend_from_slice(m.as_bytes());
         }
         if !peers_to_new_msg.is_empty() {
@@ -68,7 +76,7 @@ fn handle_relay_timeout(
         if !channel.users.is_empty() {
             let mut payload = Vec::new();
             for u in &channel.users {
-                let m = format!("MODE SERVER_RELAY {}\n", u.name);
+                let m = format!("{} {} {}\n", MSG_MODE, MSG_SERVER_RELAY, u.name);
                 payload.extend_from_slice(m.as_bytes());
             }
 
@@ -93,7 +101,7 @@ fn handle_timed_out_user(
         user_name, server_id, channel_name
     );
 
-    let msg = format!("USER_LEFT {} {}\n", user_name, user_addr);
+    let msg = format!("{MSG_USER_LEFT} {user_name} {user_addr}\n");
     let peers_to_notify: Vec<SocketAddr> = channel
         .users
         .iter()
@@ -117,7 +125,10 @@ fn handle_timed_out_user(
         handle_relay_timeout(channel, notifications);
     } else if channel.users.len() == 1 {
         channel.relay = Some(channel.users[0].name.clone());
-        notifications.push((vec![channel.users[0].addr], b"MODE RELAY\n".to_vec()));
+        notifications.push((
+            vec![channel.users[0].addr],
+            format!("{MSG_MODE} {MSG_RELAY}\n").as_bytes().to_vec(),
+        ));
     }
 }
 
@@ -164,7 +175,7 @@ fn process_channel_heartbeat(
             //announce it
             notifications.push((
                 vec![solo.addr],
-                format!("MODE SERVER_RELAY {}\n", solo.name).into_bytes(),
+                format!("{} {} {}\n", MSG_MODE, MSG_SERVER_RELAY, solo.name).into_bytes(),
             ));
         }
     }
@@ -209,8 +220,8 @@ async fn collect_heartbeat_data(
 
 async fn send_pings(socket: Arc<UdpSocket>, to_ping: Vec<SocketAddr>) {
     for addr in to_ping {
-        if let Err(e) = socket.send_to(b"PING", addr).await {
-            eprintln!("Failed to send PING: {}", e);
+        if let Err(e) = socket.send_to(MSG_PING.as_bytes(), addr).await {
+            eprintln!("Failed to send {MSG_PING}: {e}");
         }
     }
 }

--- a/src/signaling/mod.rs
+++ b/src/signaling/mod.rs
@@ -4,3 +4,6 @@ pub mod structures;
 pub mod utils;
 
 pub use handlers::handle_message;
+
+#[cfg(test)]
+mod tests;

--- a/src/signaling/structures.rs
+++ b/src/signaling/structures.rs
@@ -18,6 +18,19 @@ pub struct User {
     pub nat_kind: NatKind,
 }
 
+impl User {
+    pub fn new(user_name: &str, addr: SocketAddr, nat_kind: NatKind, peer_id: u32) -> Self {
+        Self {
+            peer_id,
+            name: user_name.to_string(),
+            addr,
+            last_pong: Instant::now(),
+            needs_server_relay: matches!(nat_kind, NatKind::Symmetric),
+            nat_kind,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Channel {
     pub channel_id: u32,

--- a/src/signaling/structures.rs
+++ b/src/signaling/structures.rs
@@ -33,7 +33,7 @@ impl User {
 
 #[derive(Clone, Debug)]
 pub struct Channel {
-    pub channel_id: u32,
+    pub channel_id: u64,
     pub next_peer_id: u32,
     pub users: Vec<User>,
     pub relay: Option<String>,

--- a/src/signaling/structures.rs
+++ b/src/signaling/structures.rs
@@ -10,6 +10,7 @@ pub enum NatKind {
 
 #[derive(Clone, Debug)]
 pub struct User {
+    pub peer_id: u32,
     pub name: String,
     pub addr: SocketAddr,
     pub last_pong: Instant,
@@ -17,10 +18,23 @@ pub struct User {
     pub nat_kind: NatKind,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Channel {
+    pub channel_id: u32,
+    pub next_peer_id: u32,
     pub users: Vec<User>,
     pub relay: Option<String>,
+}
+
+impl Default for Channel {
+    fn default() -> Self {
+        Self {
+            channel_id: 0,
+            next_peer_id: 1,
+            users: Vec::new(),
+            relay: None,
+        }
+    }
 }
 
 pub type ServerMap = HashMap<String, HashMap<String, Channel>>;

--- a/src/signaling/tests.rs
+++ b/src/signaling/tests.rs
@@ -32,19 +32,6 @@ mod tests {
         assert!(user.needs_server_relay);
     }
 
-    #[test]
-    fn generate_channel_id_returns_non_zero() {
-        let id = generate_channel_id();
-        assert_ne!(id, 0);
-    }
-
-    #[test]
-    fn generate_channel_id_is_not_constant() {
-        let a = generate_channel_id();
-        let b = generate_channel_id();
-        assert_ne!(a, b);
-    }
-
     #[tokio::test]
     async fn create_new_user_sets_fields_correctly() {
         let addr: std::net::SocketAddr = "127.0.0.1:5000".parse().unwrap();

--- a/src/signaling/tests.rs
+++ b/src/signaling/tests.rs
@@ -1,10 +1,12 @@
-use crate::signaling::handlers::utils::{add_new_user, make_channel_id, update_existing_user};
+use crate::signaling::handlers::utils::{add_new_user, update_existing_user};
 
 use crate::signaling::structures::{Channel, NatKind, User};
 use std::sync::Arc;
 
 #[cfg(test)]
 mod tests {
+    use crate::signaling::utils::generate_channel_id;
+
     use super::*;
 
     #[test]
@@ -31,23 +33,15 @@ mod tests {
     }
 
     #[test]
-    fn make_channel_id_is_stable_for_same_input() {
-        let a = make_channel_id("server1", "channel1");
-        let b = make_channel_id("server1", "channel1");
-        assert_eq!(a, b);
+    fn generate_channel_id_returns_non_zero() {
+        let id = generate_channel_id();
+        assert_ne!(id, 0);
     }
 
     #[test]
-    fn make_channel_id_differs_for_different_channels() {
-        let a = make_channel_id("server1", "channel1");
-        let b = make_channel_id("server1", "channel2");
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn make_channel_id_differs_for_different_servers() {
-        let a = make_channel_id("server1", "channel1");
-        let b = make_channel_id("server2", "channel1");
+    fn generate_channel_id_is_not_constant() {
+        let a = generate_channel_id();
+        let b = generate_channel_id();
         assert_ne!(a, b);
     }
 

--- a/src/signaling/tests.rs
+++ b/src/signaling/tests.rs
@@ -1,6 +1,4 @@
-use crate::signaling::handlers::utils::{
-    add_new_user, create_new_user, make_channel_id, update_existing_user,
-};
+use crate::signaling::handlers::utils::{add_new_user, make_channel_id, update_existing_user};
 
 use crate::signaling::structures::{Channel, NatKind, User};
 use std::sync::Arc;
@@ -8,6 +6,29 @@ use std::sync::Arc;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn user_new_sets_fields_correctly() {
+        let addr: std::net::SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+        let user = User::new("name", addr, NatKind::Cone, 7);
+
+        assert_eq!(user.name, "name");
+        assert_eq!(user.addr, addr);
+        assert_eq!(user.peer_id, 7);
+        assert!(!user.needs_server_relay);
+        assert_eq!(user.nat_kind, NatKind::Cone);
+    }
+
+    #[test]
+    fn user_new_marks_symmetric_as_server_relay() {
+        let addr: std::net::SocketAddr = "127.0.0.1:5001".parse().unwrap();
+
+        let user = User::new("name", addr, NatKind::Symmetric, 9);
+
+        assert_eq!(user.peer_id, 9);
+        assert!(user.needs_server_relay);
+    }
 
     #[test]
     fn make_channel_id_is_stable_for_same_input() {
@@ -34,7 +55,7 @@ mod tests {
     async fn create_new_user_sets_fields_correctly() {
         let addr: std::net::SocketAddr = "127.0.0.1:5000".parse().unwrap();
 
-        let user = create_new_user("name", addr, NatKind::Cone, 7).await;
+        let user = User::new("name", addr, NatKind::Cone, 7);
 
         assert_eq!(user.name, "name");
         assert_eq!(user.addr, addr);
@@ -47,7 +68,7 @@ mod tests {
     async fn create_new_user_marks_symmetric_as_server_relay() {
         let addr: std::net::SocketAddr = "127.0.0.1:5000".parse().unwrap();
 
-        let user = create_new_user("name", addr, NatKind::Symmetric, 9).await;
+        let user = User::new("name", addr, NatKind::Symmetric, 9);
 
         assert_eq!(user.peer_id, 9);
         assert!(user.needs_server_relay);

--- a/src/signaling/tests.rs
+++ b/src/signaling/tests.rs
@@ -1,0 +1,131 @@
+use crate::signaling::handlers::utils::{
+    add_new_user, create_new_user, make_channel_id, update_existing_user,
+};
+
+use crate::signaling::structures::{Channel, NatKind, User};
+use std::sync::Arc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn make_channel_id_is_stable_for_same_input() {
+        let a = make_channel_id("server1", "channel1");
+        let b = make_channel_id("server1", "channel1");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn make_channel_id_differs_for_different_channels() {
+        let a = make_channel_id("server1", "channel1");
+        let b = make_channel_id("server1", "channel2");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn make_channel_id_differs_for_different_servers() {
+        let a = make_channel_id("server1", "channel1");
+        let b = make_channel_id("server2", "channel1");
+        assert_ne!(a, b);
+    }
+
+    #[tokio::test]
+    async fn create_new_user_sets_fields_correctly() {
+        let addr: std::net::SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+        let user = create_new_user("name", addr, NatKind::Cone, 7).await;
+
+        assert_eq!(user.name, "name");
+        assert_eq!(user.addr, addr);
+        assert_eq!(user.peer_id, 7);
+        assert!(!user.needs_server_relay);
+        assert_eq!(user.nat_kind, NatKind::Cone);
+    }
+
+    #[tokio::test]
+    async fn create_new_user_marks_symmetric_as_server_relay() {
+        let addr: std::net::SocketAddr = "127.0.0.1:5000".parse().unwrap();
+
+        let user = create_new_user("name", addr, NatKind::Symmetric, 9).await;
+
+        assert_eq!(user.peer_id, 9);
+        assert!(user.needs_server_relay);
+        assert_eq!(user.nat_kind, NatKind::Symmetric);
+    }
+
+    #[tokio::test]
+    async fn add_new_user_assigns_incrementing_peer_ids() {
+        let mut channel = Channel {
+            channel_id: 123,
+            next_peer_id: 1,
+            users: Vec::new(),
+            relay: None,
+        };
+
+        let socket = Arc::new(tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap());
+
+        let addr1: std::net::SocketAddr = "127.0.0.1:6001".parse().unwrap();
+        let (updated_channel, peer_id1) =
+            add_new_user(&mut channel, "name1", addr1, &socket, NatKind::Cone).await;
+
+        assert_eq!(peer_id1, 1);
+        assert_eq!(updated_channel.users.len(), 1);
+        assert_eq!(updated_channel.users[0].peer_id, 1);
+        assert_eq!(updated_channel.next_peer_id, 2);
+
+        let addr2: std::net::SocketAddr = "127.0.0.1:6002".parse().unwrap();
+        let (updated_channel, peer_id2) =
+            add_new_user(&mut channel, "name2", addr2, &socket, NatKind::Cone).await;
+
+        assert_eq!(peer_id2, 2);
+        assert_eq!(updated_channel.users.len(), 2);
+        assert_eq!(updated_channel.users[1].peer_id, 2);
+        assert_eq!(updated_channel.next_peer_id, 3);
+    }
+
+    #[tokio::test]
+    async fn update_existing_user_returns_existing_peer_id() {
+        let addr: std::net::SocketAddr = "127.0.0.1:7001".parse().unwrap();
+
+        let mut channel = Channel {
+            channel_id: 123,
+            next_peer_id: 2,
+            users: vec![User {
+                peer_id: 1,
+                name: "name".to_string(),
+                addr,
+                last_pong: std::time::Instant::now(),
+                needs_server_relay: false,
+                nat_kind: NatKind::Cone,
+            }],
+            relay: None,
+        };
+
+        let result = update_existing_user(&mut channel, "name", addr).await;
+
+        assert!(result.is_some());
+
+        let (updated_channel, is_new, peer_id) = result.unwrap();
+        assert!(!is_new);
+        assert_eq!(peer_id, 1);
+        assert_eq!(updated_channel.users.len(), 1);
+        assert_eq!(updated_channel.users[0].peer_id, 1);
+    }
+
+    #[tokio::test]
+    async fn update_existing_user_returns_none_for_missing_user() {
+        let addr: std::net::SocketAddr = "127.0.0.1:7002".parse().unwrap();
+
+        let mut channel = Channel {
+            channel_id: 123,
+            next_peer_id: 1,
+            users: Vec::new(),
+            relay: None,
+        };
+
+        let result = update_existing_user(&mut channel, "name", addr).await;
+
+        assert!(result.is_none());
+    }
+}

--- a/src/signaling/utils.rs
+++ b/src/signaling/utils.rs
@@ -1,9 +1,15 @@
 use std::net::SocketAddr;
 
+use rand::{RngCore, rngs::OsRng};
+
 //helper to avoid moving Vec in pattern
 pub fn cleanup_and_notify_iter<I>(it: I) -> Vec<(Vec<SocketAddr>, Vec<u8>)>
 where
     I: IntoIterator<Item = (Vec<SocketAddr>, Vec<u8>)>,
 {
     it.into_iter().collect()
+}
+
+pub fn generate_channel_id() -> u64 {
+    OsRng.next_u64()
 }


### PR DESCRIPTION
- added peer_id to signaling users
- added channel_id and next_peer_id to channel state
- channel id is now generated per channel in a stable way
- peer_id values are incrementaly assigned to newly connected users
- binary CONTROL WELCOME <channel_id> <peer_id> are sent on every valid CONNECT/reconnect
- WELCOME is parsed on client and channel_id/my_peer_id are stored locally
- Added some Unit Tests for channel ID generation and user creation/update helpers
- Centralized protocol text tokens into constants to eliminate typo mistakes
- Deleted the unnecessary CONTROL_TEST logic, because we added the newly WELCOME Control message