### PR TITLE
Adding pedantic linting and fixing linter errors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,8 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
+    - name: Clippy 
+      run: cargo clippy --release -- -D warnings
     - name: Run tests
       run: cargo test --verbose
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,7 @@ tokio-tungstenite = "0.23"
 futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-
 openssl = { version = "0.10.76", features = ["vendored"] }
+
+[lints.clippy]
+pedantic = "warn"

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -497,9 +497,9 @@ fn main() -> std::io::Result<()> {
 
     start_heartbeat(
         socket.try_clone()?,
-        server_id.to_string(),
-        channel.to_string(),
-        user.to_string(),
+        server_id.clone(),
+        channel.clone(),
+        user.clone(),
         signaling_addr.clone(),
     );
 
@@ -534,8 +534,8 @@ fn main() -> std::io::Result<()> {
         socket.try_clone()?,
         Arc::clone(&peers),
         Arc::clone(&relay_started),
-        server_id.to_string(),
-        channel.to_string(),
+        server_id.clone(),
+        channel.clone(),
         signaling_addr.clone(),
         Arc::clone(&relay_sync),
     );
@@ -544,7 +544,7 @@ fn main() -> std::io::Result<()> {
     start_user_input(
         socket.try_clone()?,
         Arc::clone(&peers),
-        user.to_string(),
+        user.clone(),
         Arc::clone(&send_via_server),
         signaling_addr.clone(),
         Arc::clone(&is_relay),

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -11,8 +11,8 @@ use std::{
 
 use od_nat_piercer::{
     client::{
-        handlers::*,
-        networking::*,
+        handlers::{try_handle_welcome, process_incoming_message, handle_peer_message},
+        networking::{detect_nat_kind, start_heartbeat, start_hole_punching, start_relay_keepalive, start_user_input},
         structures::{NatKind, PeerInfo, PunchState, PunchSync, RelayState, RelaySync},
     },
     proto::{
@@ -70,7 +70,7 @@ fn send_connect_message(
 
     let connect_msg = format!("{MSG_CONNECT} {server_id} {channel} {user} {nat_type}");
     socket
-        .send_to(connect_msg.as_bytes(), &signaling_addr)
+        .send_to(connect_msg.as_bytes(), signaling_addr)
         .expect("Failed to send CONNECT");
     println!("Sent {MSG_CONNECT} to signaling server");
 }
@@ -103,7 +103,7 @@ fn process_server_response(
     {
         return;
     }
-    println!("Server response:\n{}", response);
+    println!("Server response:\n{response}");
     for line in response.lines() {
         let line = line.trim();
 
@@ -184,7 +184,7 @@ fn handle_recv_result(
                         //temporarly: if payload is text, process as before
                         if let Ok(s) = std::str::from_utf8(payload) {
                             println!("(setup) {MSG_CONTROL} payload: {}", s.trim());
-                            try_handle_welcome(s, &channel_id, &my_peer_id);
+                            try_handle_welcome(s, channel_id, my_peer_id);
                             if &src == server_socketaddr {
                                 if s.lines()
                                     .any(|l| l.trim_start().starts_with(&format!("{MSG_MODE} ")))
@@ -198,7 +198,7 @@ fn handle_recv_result(
                                     s,
                                     src,
                                     peers,
-                                    &user,
+                                    user,
                                     is_relay,
                                     channel_has_server_relays,
                                     signaling_addr,
@@ -228,7 +228,7 @@ fn handle_recv_result(
                                     s,
                                     src,
                                     peers,
-                                    &user,
+                                    user,
                                     is_relay,
                                     channel_has_server_relays,
                                     signaling_addr,
@@ -260,7 +260,7 @@ fn handle_recv_result(
                     &resp,
                     src,
                     peers,
-                    &user,
+                    user,
                     is_relay,
                     channel_has_server_relays,
                     signaling_addr,
@@ -286,7 +286,7 @@ fn handle_recv_result(
                     &resp,
                     src,
                     peers,
-                    &user,
+                    user,
                     is_relay,
                     channel_has_server_relays,
                     signaling_addr,
@@ -299,7 +299,7 @@ fn handle_recv_result(
             true
         }
         Err(e) => {
-            eprintln!("recv error during setup: {}", e);
+            eprintln!("recv error during setup: {e}");
             false
         }
     }
@@ -339,8 +339,8 @@ fn server_responses_during_setup(
             &mut saw_mode,
             punch_sync,
             relay_sync,
-            &channel_id,
-            &my_peer_id,
+            channel_id,
+            my_peer_id,
         ) {
             break;
         }
@@ -373,7 +373,7 @@ fn main_loop(
                             println!("Got {MSG_CONTROL} {} bytes from {src}", payload.len());
                             if let Ok(s) = std::str::from_utf8(payload) {
                                 println!("{MSG_CONTROL} payload: {}", s.trim());
-                                try_handle_welcome(s, &channel_id, &my_peer_id);
+                                try_handle_welcome(s, channel_id, my_peer_id);
 
                                 process_incoming_message(
                                     socket,
@@ -419,7 +419,7 @@ fn main_loop(
                     );
                 } else {
                     // Peer traffic
-                    handle_peer_message(&peers, src);
+                    handle_peer_message(peers, src);
 
                     process_incoming_message(
                         socket,
@@ -439,7 +439,7 @@ fn main_loop(
                 thread::sleep(Duration::from_millis(MAIN_POLL_SLEEP_MS));
             }
             Err(e) => {
-                eprintln!("Error receiving: {}", e);
+                eprintln!("Error receiving: {e}");
                 return Err(e);
             }
         }
@@ -457,10 +457,10 @@ fn main() -> std::io::Result<()> {
 
     // NAT detection before CONNECT
     let my_nat = detect_nat_kind(&socket, &signaling_ip);
-    println!("My NAT kind: {:?}", my_nat);
+    println!("My NAT kind: {my_nat:?}");
 
     //Address for the signalization server (UDP on port 2131)
-    let signaling_addr = format!("{}:2131", signaling_ip);
+    let signaling_addr = format!("{signaling_ip}:2131");
     let server_socketaddr: std::net::SocketAddr = signaling_addr
         .to_socket_addrs()
         .expect("resolve signaling server")
@@ -519,14 +519,14 @@ fn main() -> std::io::Result<()> {
     );
 
     // start punching ONLY if NAT is not symmetric
-    if my_nat != NatKind::Symmetric {
+    if my_nat == NatKind::Symmetric {
+        println!("Symmetric NAT detected - skipping hole punching, relying on server relay.");
+    } else {
         start_hole_punching(
             socket.try_clone()?,
             Arc::clone(&peers),
             Arc::clone(&punch_sync),
         );
-    } else {
-        println!("Symmetric NAT detected - skipping hole punching, relying on server relay.");
     }
 
     //Relay keepalive thread starter

--- a/src/bin/signaling_server.rs
+++ b/src/bin/signaling_server.rs
@@ -46,11 +46,10 @@ async fn run_server(
             res = socket_main.recv_from(&mut buf_main) => {
                 if let Ok((len,src)) = res{
                     if let Some((hdr, payload)) = od_nat_piercer::proto::packet::decode(&buf_main[..len]){
-                        if hdr.kind == od_nat_piercer::proto::packet::Kind::Control{
-                            if let Ok(s) = std::str::from_utf8(payload){
+                        if hdr.kind == od_nat_piercer::proto::packet::Kind::Control
+                            && let Ok(s) = std::str::from_utf8(payload){
                                 handle_message(s.to_string(), src, Arc::clone(&socket_main), Arc::clone(&state)).await;
                             }
-                        }
                         continue;
                     }
                     let msg = String::from_utf8_lossy(&buf_main[..len]).to_string();
@@ -61,11 +60,10 @@ async fn run_server(
             res = socket_probe.recv_from(&mut buf_probe) => {
                 if let Ok((len,src)) = res{
                     if let Some((hdr, payload)) = od_nat_piercer::proto::packet::decode(&buf_main[..len]){
-                        if hdr.kind == od_nat_piercer::proto::packet::Kind::Control{
-                            if let Ok(s) = std::str::from_utf8(payload){
+                        if hdr.kind == od_nat_piercer::proto::packet::Kind::Control
+                            && let Ok(s) = std::str::from_utf8(payload){
                                 handle_message(s.to_string(), src, Arc::clone(&socket_probe), Arc::clone(&state)).await;
                             }
-                        }
                         continue;
                     }
 

--- a/src/bin/signaling_server.rs
+++ b/src/bin/signaling_server.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tokio::spawn(async move {
         if let Err(e) = start_control_server("0.0.0.0:2133", control_peers_clone).await {
-            eprintln!("control server failed: {}", e);
+            eprintln!("control server failed: {e}");
         }
     });
 

--- a/src/client/handlers.rs
+++ b/src/client/handlers.rs
@@ -18,13 +18,12 @@ use std::{
 pub fn try_handle_welcome(s: &str, channel_id: &Arc<AtomicU64>, my_peer_id: &Arc<AtomicU32>) {
     for line in s.lines() {
         let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() == 3 && parts[0] == MSG_WELCOME {
-            if let (Ok(cid), Ok(pid)) = (parts[1].parse::<u64>(), parts[2].parse::<u32>()) {
+        if parts.len() == 3 && parts[0] == MSG_WELCOME
+            && let (Ok(cid), Ok(pid)) = (parts[1].parse::<u64>(), parts[2].parse::<u32>()) {
                 channel_id.store(cid, Ordering::Release);
                 my_peer_id.store(pid, Ordering::Release);
                 println!("{MSG_WELCOME} received: channel_id={cid}, my_peer_id={pid}");
             }
-        }
     }
 }
 
@@ -41,7 +40,9 @@ fn handle_mode_direct(parts: &[&str], peers: &Arc<Mutex<Vec<PeerInfo>>>, me: &st
     let addr_str = parts[3];
     if let Ok(addr) = SocketAddr::from_str(addr_str) {
         let mut guard = peers.lock().unwrap();
-        if username != me {
+        if username == me {
+            println!("Server confirms you ({me}) are relay for {addr_str}");
+        } else {
             if !guard.iter().any(|p| p.addr == addr) {
                 guard.push(PeerInfo {
                     addr,
@@ -53,10 +54,8 @@ fn handle_mode_direct(parts: &[&str], peers: &Arc<Mutex<Vec<PeerInfo>>>, me: &st
                     relay_requested: false,
                     nat_kind: NatKind::Unknown,
                 });
-                println!("Added peer {} with addr {}", username, addr_str);
+                println!("Added peer {username} with addr {addr_str}");
             }
-        } else {
-            println!("Server confirms you ({}) are relay for {}", me, addr_str);
         }
     }
 }
@@ -64,8 +63,8 @@ fn handle_mode_direct(parts: &[&str], peers: &Arc<Mutex<Vec<PeerInfo>>>, me: &st
 fn handle_user_left(parts: &[&str], peers: &Arc<Mutex<Vec<PeerInfo>>>) {
     let username = parts[1];
     let mut guard = peers.lock().unwrap();
-    guard.retain(|p| p.username != username.to_string());
-    println!("[CLIENT:user] {} left, removed from list", username);
+    guard.retain(|p| p.username != username);
+    println!("[CLIENT:user] {username} left, removed from list");
 }
 
 fn handle_unrecognized_command(line: &str) {
@@ -77,7 +76,7 @@ fn handle_unrecognized_command(line: &str) {
         return;
     }
 
-    println!("Unhandled control line: {}", line);
+    println!("Unhandled control line: {line}");
 }
 
 pub fn handle_mode_line(
@@ -111,7 +110,7 @@ pub fn handle_mode_line(
                             println!("Relay: channel has server-relayed peers.");
                         }
                     } else {
-                        println!("Server will relay for user: {}", username);
+                        println!("Server will relay for user: {username}");
                     }
 
                     //mark that peer as server-relayed to stop punching it
@@ -160,12 +159,12 @@ pub fn ensure_connected(p: &mut PeerInfo, con_type: &str) {
 }
 
 pub fn handle_hole_punch(peers: &Arc<Mutex<Vec<PeerInfo>>>, src: std::net::SocketAddr) {
-    println!("Received hole punch from {}", src);
+    println!("Received hole punch from {src}");
     let mut peers_guard = peers.lock().unwrap();
     if let Some(peer) = peers_guard.iter_mut().find(|p| p.addr == src) {
         ensure_connected(peer, "punch");
     } else {
-        println!("Hole punch received from unknown peer: {}", src);
+        println!("Hole punch received from unknown peer: {src}");
     }
 }
 
@@ -177,11 +176,10 @@ fn handle_relay_message_to_peers(
 ) {
     let peers_guard = peers.lock().unwrap();
     for peer in peers_guard.iter() {
-        if peer.username != sender {
-            if let Err(e) = socket.send_to(message.as_bytes(), peer.addr) {
+        if peer.username != sender
+            && let Err(e) = socket.send_to(message.as_bytes(), peer.addr) {
                 eprintln!("Failed to send data to {}: {}", peer.addr, e);
             }
-        }
     }
 }
 
@@ -198,7 +196,7 @@ pub fn handle_data_message(
         if parts.len() >= 3 {
             let sender = parts[1];
             let text = parts[2];
-            println!("[{}]: {}", sender, text);
+            println!("[{sender}]: {text}");
 
             //NO MATTER THE SOURCE, we've observed sender activity
             mark_peer_connected_by_name(peers, sender);

--- a/src/client/handlers.rs
+++ b/src/client/handlers.rs
@@ -42,20 +42,18 @@ fn handle_mode_direct(parts: &[&str], peers: &Arc<Mutex<Vec<PeerInfo>>>, me: &st
         let mut guard = peers.lock().unwrap();
         if username == me {
             println!("Server confirms you ({me}) are relay for {addr_str}");
-        } else {
-            if !guard.iter().any(|p| p.addr == addr) {
-                guard.push(PeerInfo {
-                    addr,
-                    last_pong: Instant::now(),
-                    username: username.to_string(),
-                    connected: false,
-                    created_at: Instant::now(),
-                    use_server_relay: false,
-                    relay_requested: false,
-                    nat_kind: NatKind::Unknown,
-                });
-                println!("Added peer {username} with addr {addr_str}");
-            }
+        } else if !guard.iter().any(|p| p.addr == addr) {
+            guard.push(PeerInfo {
+                addr,
+                last_pong: Instant::now(),
+                username: username.to_string(),
+                connected: false,
+                created_at: Instant::now(),
+                use_server_relay: false,
+                relay_requested: false,
+                nat_kind: NatKind::Unknown,
+            });
+            println!("Added peer {username} with addr {addr_str}");
         }
     }
 }

--- a/src/client/networking.rs
+++ b/src/client/networking.rs
@@ -20,9 +20,9 @@ const CONNECT_GRACE_SEC: u64 = 12; // wait for connection for this time, after t
 const NAT_DETECT_TOTAL_TIMEOUT_MS: u64 = 600; // maximum waiting time for server to respond to both probes
 const NAT_DETECT_POLL_SLEEP_MS: u64 = 20; // sleep between polls when socket is WouldBlock
 
-pub fn detect_nat_kind(socket: &UdpSocket, signaling_ip: &str) -> NatKind {
-    let addr1 = format!("{}:2131", signaling_ip);
-    let addr2 = format!("{}:2132", signaling_ip);
+#[must_use] pub fn detect_nat_kind(socket: &UdpSocket, signaling_ip: &str) -> NatKind {
+    let addr1 = format!("{signaling_ip}:2131");
+    let addr2 = format!("{signaling_ip}:2132");
 
     let _ = socket.send_to(format!("{MSG_NAT_PROBE} 1\n").as_bytes(), &addr1);
     let _ = socket.send_to(format!("{MSG_NAT_PROBE} 2\n").as_bytes(), &addr2);
@@ -35,13 +35,11 @@ pub fn detect_nat_kind(socket: &UdpSocket, signaling_ip: &str) -> NatKind {
         match socket.recv_from(&mut buf) {
             Ok((len, _src)) => {
                 let msg = String::from_utf8_lossy(&buf[..len]).to_string();
-                if msg.starts_with(&format!("{MSG_NAT_SEEN} ")) {
-                    if let Some(addr_str) = msg.split_whitespace().nth(1) {
-                        if let Ok(observed) = addr_str.parse::<std::net::SocketAddr>() {
+                if msg.starts_with(&format!("{MSG_NAT_SEEN} "))
+                    && let Some(addr_str) = msg.split_whitespace().nth(1)
+                        && let Ok(observed) = addr_str.parse::<std::net::SocketAddr>() {
                             seen.push(observed);
                         }
-                    }
-                }
             }
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 std::thread::sleep(Duration::from_millis(NAT_DETECT_POLL_SLEEP_MS));
@@ -168,7 +166,7 @@ fn handle_peer_timeout(
             server_id, channel, peer.username
         )
         .as_bytes(),
-        &signaling_addr,
+        signaling_addr,
     );
 }
 
@@ -263,7 +261,7 @@ fn relay_keepalive_loop(
             let mut started = relay_started.lock().unwrap();
             if !*started {
                 *started = true;
-                println!("Starting relay keepalive thread.")
+                println!("Starting relay keepalive thread.");
             }
         }
 
@@ -353,24 +351,22 @@ fn user_input_loop(
 ) {
     use std::io::{self, BufRead};
     let stdin = io::stdin();
-    for line in stdin.lock().lines() {
-        if let Ok(msg) = line {
-            let msg = msg.trim();
-            if msg.is_empty() {
-                continue;
-            }
-            let s = send_via_server.load(Ordering::Acquire);
-            handle_user_message(
-                &socket,
-                &peers,
-                &username,
-                msg,
-                s,
-                &signaling_addr,
-                &is_relay,
-                &channel_has_server_relays,
-            );
+    for msg in stdin.lock().lines().flatten() {
+        let msg = msg.trim();
+        if msg.is_empty() {
+            continue;
         }
+        let s = send_via_server.load(Ordering::Acquire);
+        handle_user_message(
+            &socket,
+            &peers,
+            &username,
+            msg,
+            s,
+            &signaling_addr,
+            &is_relay,
+            &channel_has_server_relays,
+        );
     }
 }
 

--- a/src/client/networking.rs
+++ b/src/client/networking.rs
@@ -62,10 +62,10 @@ const NAT_DETECT_POLL_SLEEP_MS: u64 = 20; // sleep between polls when socket is 
     }
 
     if a.port() == b.port() {
-        println!("NAT detection: {NAT_TYPE_CONE} (same addr on both ports): {a}",);
+        println!("NAT detection: {NAT_TYPE_CONE} (same addr on both ports): {a}");
         NatKind::Cone
     } else {
-        println!("NAT detection: {NAT_TYPE_SYMMETRIC} (different ports): {a} vs {b}",);
+        println!("NAT detection: {NAT_TYPE_SYMMETRIC} (different ports): {a} vs {b}");
         NatKind::Symmetric
     }
 }

--- a/src/control/server.rs
+++ b/src/control/server.rs
@@ -17,7 +17,7 @@ pub(crate) fn channel_key(server_id: &str, channel: &str) -> String {
 
 pub async fn start_control_server(addr: &str, peers: ControlPeers) -> std::io::Result<()> {
     let listener = TcpListener::bind(addr).await?;
-    println!("Control WebSocket server listening on {}", addr);
+    println!("Control WebSocket server listening on {addr}");
 
     loop {
         let (stream, _) = listener.accept().await?;
@@ -25,7 +25,7 @@ pub async fn start_control_server(addr: &str, peers: ControlPeers) -> std::io::R
 
         tokio::spawn(async move {
             if let Err(e) = handle_connection(stream, peers).await {
-                eprintln!("control ws connection error: {}", e);
+                eprintln!("control ws connection error: {e}");
             }
         });
     }

--- a/src/proto/packet.rs
+++ b/src/proto/packet.rs
@@ -11,7 +11,7 @@ pub enum Kind {
 }
 
 impl Kind {
-    pub fn from_u8(v: u8) -> Option<Self> {
+    #[must_use] pub fn from_u8(v: u8) -> Option<Self> {
         match v {
             1 => Some(Kind::Control),
             2 => Some(Kind::Dtls),
@@ -35,7 +35,7 @@ pub struct Header {
 pub const HEADER_LEN: usize = 30;
 
 impl Header {
-    pub fn control(channel_id: u64, src_peer_id: u32, dst_peer_id: u32, payload_len: u16) -> Self {
+    #[must_use] pub fn control(channel_id: u64, src_peer_id: u32, dst_peer_id: u32, payload_len: u16) -> Self {
         Self {
             kind: Kind::Control,
             flags: 0,
@@ -47,12 +47,12 @@ impl Header {
         }
     }
 
-    pub fn welcome(channel_id: u64, dst_peer_id: u32, payload_len: u16) -> Self {
+    #[must_use] pub fn welcome(channel_id: u64, dst_peer_id: u32, payload_len: u16) -> Self {
         Self::control(channel_id, 0, dst_peer_id, payload_len)
     }
 }
 
-pub fn encode(h: Header, payload: &[u8]) -> Vec<u8> {
+#[must_use] pub fn encode(h: Header, payload: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(HEADER_LEN + payload.len());
     out.extend_from_slice(&MAGIC);
     out.push(VERSION);
@@ -68,7 +68,7 @@ pub fn encode(h: Header, payload: &[u8]) -> Vec<u8> {
     out
 }
 
-pub fn decode(buf: &[u8]) -> Option<(Header, &[u8])> {
+#[must_use] pub fn decode(buf: &[u8]) -> Option<(Header, &[u8])> {
     if buf.len() < HEADER_LEN {
         return None;
     }

--- a/src/signaling/handlers/heartbeat.rs
+++ b/src/signaling/handlers/heartbeat.rs
@@ -18,15 +18,13 @@ pub async fn handle_heartbeat(parts: &[&str], src: SocketAddr, state: Arc<Mutex<
     let channel_name = parts[2];
     let user_name = parts[3];
     let mut st = state.lock().await;
-    if let Some(channels) = st.get_mut(server_id) {
-        if let Some(channel) = channels.get_mut(channel_name) {
-            if let Some(u) = channel
+    if let Some(channels) = st.get_mut(server_id)
+        && let Some(channel) = channels.get_mut(channel_name)
+            && let Some(u) = channel
                 .users
                 .iter_mut()
                 .find(|u| u.name == user_name && u.addr == src)
             {
                 u.last_pong = Instant::now();
             }
-        }
-    }
 }

--- a/src/signaling/handlers/message.rs
+++ b/src/signaling/handlers/message.rs
@@ -26,7 +26,7 @@ pub async fn handle_message(
         return;
     }
 
-    let parts: Vec<&str> = msg.trim().split_whitespace().collect();
+    let parts: Vec<&str> = msg.split_whitespace().collect();
 
     if msg.trim() == MSG_PONG {
         handle_pong(src, state).await;
@@ -38,7 +38,7 @@ pub async fn handle_message(
         return;
     }
 
-    if parts.len() >= 1 {
+    if !parts.is_empty() {
         match parts[0] {
             MSG_CONNECT if parts.len() >= 4 => {
                 handle_connect_message(&parts, src, socket, state).await;

--- a/src/signaling/handlers/notifications.rs
+++ b/src/signaling/handlers/notifications.rs
@@ -21,15 +21,14 @@ pub async fn mark_relay_in_channel(
     relay_user: &User,
 ) -> bool {
     let mut st = state.lock().await;
-    if let Some(channels) = st.get_mut(server_id) {
-        if let Some(channel) = channels.get_mut(channel_name) {
+    if let Some(channels) = st.get_mut(server_id)
+        && let Some(channel) = channels.get_mut(channel_name) {
             if channel.relay.as_deref() == Some(&relay_user.name) {
                 return false;
             }
             channel.relay = Some(relay_user.name.clone());
             return true;
         }
-    }
     false
 }
 
@@ -73,7 +72,7 @@ pub async fn notify_existing_users_about_new_user(
     new_user_name: &str,
     new_user_addr: SocketAddr,
 ) {
-    for user in users.iter() {
+    for user in users {
         if user.addr != new_user_addr {
             let msg_to_existing =
                 format!("{MSG_MODE} {MSG_DIRECT} {new_user_name} {new_user_addr}\n");
@@ -83,7 +82,7 @@ pub async fn notify_existing_users_about_new_user(
 
             let msg_to_new = format!("{} {} {} {}\n", MSG_MODE, MSG_DIRECT, user.name, user.addr);
             if let Err(e) = socket.send_to(msg_to_new.as_bytes(), new_user_addr).await {
-                eprintln!("Failed to notify new user: {}", e);
+                eprintln!("Failed to notify new user: {e}");
             }
         }
     }
@@ -108,7 +107,7 @@ pub async fn notify_lone_user(socket: &Arc<UdpSocket>, lone_user_addr: Option<So
     if let Some(lone_user_addr) = lone_user_addr {
         let reply = format!("{MSG_MODE} {MSG_RELAY}\n");
         if let Err(e) = socket.send_to(reply.as_bytes(), lone_user_addr).await {
-            eprintln!("Failed to notify lone user: {}", e);
+            eprintln!("Failed to notify lone user: {e}");
         }
     }
 }
@@ -156,9 +155,7 @@ pub async fn notify_all_about_departure(
             "{} {} {}\n",
             MSG_USER_LEFT,
             user_name,
-            leaving_user_addr
-                .map(|a| a.to_string())
-                .unwrap_or_else(|| "0.0.0.0:0".into())
+            leaving_user_addr.map_or_else(|| "0.0.0.0:0".into(), |a| a.to_string())
         );
         if let Err(e) = socket.send_to(departure_msg.as_bytes(), user.addr).await {
             eprintln!("Failed to notify {} about departure: {}", user.name, e);
@@ -194,7 +191,7 @@ pub async fn handle_multiple_users_scenario(
         let mut relay_peers: Vec<User> = Vec::new();
         let mut symmetric_peers: Vec<User> = Vec::new();
 
-        for u in users_to_notify.users.iter() {
+        for u in &users_to_notify.users {
             if u.name == relay_user.name {
                 continue;
             }
@@ -221,7 +218,7 @@ pub async fn handle_multiple_users_scenario(
         }
 
         // 5) SYMMETRIC peers: only get MODE SERVER_RELAY
-        for symmetric in symmetric_peers.iter() {
+        for symmetric in &symmetric_peers {
             let msg = format!("{} {} {}\n", MSG_MODE, MSG_SERVER_RELAY, symmetric.name);
 
             //1) send to symmetric user (to send via server)
@@ -244,11 +241,10 @@ pub async fn handle_multiple_users_scenario(
 
         // mark in state that there is no user relay
         let mut st = state.lock().await;
-        if let Some(chans) = st.get_mut(server_id) {
-            if let Some(ch) = chans.get_mut(channel_name) {
+        if let Some(chans) = st.get_mut(server_id)
+            && let Some(ch) = chans.get_mut(channel_name) {
                 ch.relay = None;
             }
-        }
     }
 }
 
@@ -285,9 +281,7 @@ pub async fn handle_relay_transition(
         if let Some(new_relay) = pick_eligible_relay(&channel) {
             let peers: Vec<User> = channel
                 .users
-                .iter()
-                .cloned()
-                .filter(|u| u.name != new_relay.name)
+                .iter().filter(|&u| u.name != new_relay.name).cloned()
                 .collect();
 
             promote_new_relay(socket, &new_relay).await;
@@ -296,11 +290,10 @@ pub async fn handle_relay_transition(
 
             //actualizam relay in state
             let mut st = state.lock().await;
-            if let Some(chans) = st.get_mut(server_id) {
-                if let Some(ch) = chans.get_mut(channel_name) {
+            if let Some(chans) = st.get_mut(server_id)
+                && let Some(ch) = chans.get_mut(channel_name) {
                     ch.relay = Some(new_relay.name.clone());
                 }
-            }
         } else {
             //no eligible user -> server remains relay, announce SERVER_RELAY for all peers
             for u in &channel.users {
@@ -311,11 +304,10 @@ pub async fn handle_relay_transition(
             }
 
             let mut st = state.lock().await;
-            if let Some(chans) = st.get_mut(server_id) {
-                if let Some(ch) = chans.get_mut(channel_name) {
+            if let Some(chans) = st.get_mut(server_id)
+                && let Some(ch) = chans.get_mut(channel_name) {
                     ch.relay = None;
                 }
-            }
         }
     }
 }
@@ -334,7 +326,7 @@ pub async fn handle_disconnect_notifications(
     if lone_user_addr.is_some() {
         notify_lone_user(&socket, lone_user_addr).await;
     } else {
-        handle_relay_transition(&socket, was_relay, &state, &server_id, &channel_name).await;
+        handle_relay_transition(&socket, was_relay, state, &server_id, &channel_name).await;
     }
     notify_all_about_departure(&socket, remaining_users, user_name, leaving_user_addr).await;
 }
@@ -351,8 +343,8 @@ pub async fn handle_peer_timeout(
 
     let remaining = {
         let mut st = state.lock().await;
-        if let Some(channels) = st.get_mut(&server_id) {
-            if let Some(channel) = channels.get_mut(&channel_name) {
+        if let Some(channels) = st.get_mut(&server_id)
+            && let Some(channel) = channels.get_mut(&channel_name) {
                 //removing by name
                 channel.users.retain(|u| u.name != peer_user);
 
@@ -361,7 +353,6 @@ pub async fn handle_peer_timeout(
                     channel.relay = Some(channel.users[0].name.clone());
                 }
             }
-        }
 
         st.get(&server_id)
             .and_then(|channels| channels.get(&channel_name))

--- a/src/signaling/handlers/request_relay.rs
+++ b/src/signaling/handlers/request_relay.rs
@@ -20,19 +20,18 @@ pub async fn handle_relay_request(
     let username = parts[3];
 
     let mut st = state.lock().await;
-    if let Some(channels) = st.get_mut(server_id) {
-        if let Some(channel) = channels.get_mut(channel_name) {
+    if let Some(channels) = st.get_mut(server_id)
+        && let Some(channel) = channels.get_mut(channel_name) {
             // mark this user that he needs server relay
             if let Some(user) = channel.users.iter_mut().find(|u| u.name == username) {
                 user.needs_server_relay = true;
             }
             // notify all users that the server will forward for the user that needs a relay
             let notify = format!("{MSG_MODE} {MSG_SERVER_RELAY} {username}\n");
-            for u in channel.users.iter() {
+            for u in &channel.users {
                 let _ = socket.send_to(notify.as_bytes(), u.addr).await;
             }
         }
-    }
 }
 
 pub async fn handle_data_from_client(
@@ -53,18 +52,16 @@ pub async fn handle_data_from_client(
     for (_sid, channels) in st.iter_mut() {
         for (_cname, channel) in channels.iter_mut() {
             // mirrored DATA from RELAY -> deliver to peers that need server relay
-            if let Some(relay_name) = &channel.relay {
-                if let Some(relay_user) = channel.users.iter().find(|u| &u.name == relay_name) {
-                    if relay_user.addr == src {
-                        for peer in channel.users.iter() {
+            if let Some(relay_name) = &channel.relay
+                && let Some(relay_user) = channel.users.iter().find(|u| &u.name == relay_name)
+                    && relay_user.addr == src {
+                        for peer in &channel.users {
                             if peer.name != sender_name && peer.needs_server_relay {
                                 let _ = socket.send_to(raw.as_bytes(), peer.addr).await;
                             }
                         }
                         return;
                     }
-                }
-            }
 
             //find the sender in this channel by (addr, name)
             if let Some(sender_index) = channel
@@ -76,14 +73,13 @@ pub async fn handle_data_from_client(
                 let sender_is_relay = channel
                     .relay
                     .as_deref()
-                    .map(|r| r == sender_name)
-                    .unwrap_or(false);
+                    .is_some_and(|r| r == sender_name);
 
                 let sender_needs_server_relay = channel.users[sender_index].needs_server_relay;
 
                 //if sender is relay -> deliver only to need_server_relay users
                 if sender_is_relay {
-                    for peer in channel.users.iter() {
+                    for peer in &channel.users {
                         if peer.name != sender_name && peer.needs_server_relay {
                             let _ = socket.send_to(raw.as_bytes(), peer.addr).await;
                         }
@@ -93,7 +89,7 @@ pub async fn handle_data_from_client(
 
                 // If sender is symmetric (needs server relay) -> deliver to everyone else
                 if sender_needs_server_relay {
-                    for peer in channel.users.iter() {
+                    for peer in &channel.users {
                         if peer.addr != src {
                             let _ = socket.send_to(raw.as_bytes(), peer.addr).await;
                         }
@@ -103,13 +99,11 @@ pub async fn handle_data_from_client(
 
                 //otherwise (unexpected normal client sent to server?)
                 // forward to the relay only
-                if let Some(relay_name) = &channel.relay {
-                    if let Some(relay_user) = channel.users.iter().find(|u| &u.name == relay_name) {
-                        if relay_user.addr != src {
+                if let Some(relay_name) = &channel.relay
+                    && let Some(relay_user) = channel.users.iter().find(|u| &u.name == relay_name)
+                        && relay_user.addr != src {
                             let _ = socket.send_to(raw.as_bytes(), relay_user.addr).await;
                         }
-                    }
-                }
                 return;
             }
         }

--- a/src/signaling/handlers/utils.rs
+++ b/src/signaling/handlers/utils.rs
@@ -49,27 +49,23 @@ pub async fn remove_old_user_sessions(
 pub async fn handle_lone_user_scenario(channel: &mut Channel, socket: &Arc<UdpSocket>) {
     if channel.relay.is_none() && channel.users.len() == 1 {
         let u = &channel.users[0];
-        match u.nat_kind {
-            NatKind::Symmetric => {
-                let reply = format!(
-                    "{} {} {}\n",
-                    MSG_MODE, MSG_SERVER_RELAY, channel.users[0].name
-                );
-                if let Err(e) = socket.send_to(reply.as_bytes(), u.addr).await {
-                    eprintln!("Failed to notify lone user about server relay: {}", e);
-                }
-                channel.relay = None;
+        if u.nat_kind == NatKind::Symmetric {
+            let reply = format!(
+                "{} {} {}\n",
+                MSG_MODE, MSG_SERVER_RELAY, channel.users[0].name
+            );
+            if let Err(e) = socket.send_to(reply.as_bytes(), u.addr).await {
+                eprintln!("Failed to notify lone user about server relay: {e}");
             }
-
-            _ => {
-                if let Err(e) = socket
-                    .send_to(format!("{MSG_MODE} {MSG_RELAY}\n").as_bytes(), u.addr)
-                    .await
-                {
-                    eprintln!("Failed to notify lone user about relay mode: {}", e);
-                }
-                channel.relay = Some(u.name.clone());
+            channel.relay = None;
+        } else {
+            if let Err(e) = socket
+                .send_to(format!("{MSG_MODE} {MSG_RELAY}\n").as_bytes(), u.addr)
+                .await
+            {
+                eprintln!("Failed to notify lone user about relay mode: {e}");
             }
+            channel.relay = Some(u.name.clone());
         }
     }
 }
@@ -92,7 +88,7 @@ pub async fn add_new_user(
 
     handle_lone_user_scenario(channel, socket).await;
 
-    println!("User {} joined from {}", user_name, src_addr);
+    println!("User {user_name} joined from {src_addr}");
 
     (channel.clone(), peer_id)
 }
@@ -111,8 +107,7 @@ pub async fn find_and_remove_user(
         let was_relay = channel
             .relay
             .as_ref()
-            .map(|r| r == &user_name)
-            .unwrap_or(false);
+            .is_some_and(|r| r == user_name);
 
         let leaving_user_addr = channel.users[pos].addr;
         channel.users.remove(pos);
@@ -130,11 +125,11 @@ pub async fn update_relay_after_departure(
     let mut lone_user_addr = None;
 
     if was_relay {
-        if !channel.users.is_empty() {
+        if channel.users.is_empty() {
+            channel.relay = None;
+        } else {
             let new_relay = channel.users[0].name.clone();
             channel.relay = Some(new_relay);
-        } else {
-            channel.relay = None;
         }
 
         if channel.users.len() == 1 {
@@ -158,8 +153,8 @@ pub async fn handle_user_removal(
     let mut leaving_user_addr = None;
     let mut lone_user_addr = None;
 
-    if let Some(channels) = st.get_mut(server_id) {
-        if let Some(channel) = channels.get_mut(channel_name) {
+    if let Some(channels) = st.get_mut(server_id)
+        && let Some(channel) = channels.get_mut(channel_name) {
             if let Some((found_was_relay, found_leaving_addr)) =
                 find_and_remove_user(channel, user_name, src_addr).await
             {
@@ -168,17 +163,15 @@ pub async fn handle_user_removal(
 
                 lone_user_addr = update_relay_after_departure(channel, was_relay).await;
 
-                println!("User {} left {}-{}", user_name, server_id, channel_name);
+                println!("User {user_name} left {server_id}-{channel_name}");
             } else {
                 println!(
-                    "Ignoring DISCONNECT for {} from {} (no matching session)",
-                    user_name, src_addr
+                    "Ignoring DISCONNECT for {user_name} from {src_addr} (no matching session)"
                 );
             }
         }
-    }
 
-    let remaining_users = get_remaining_users(&state, server_id, channel_name).await;
+    let remaining_users = get_remaining_users(state, server_id, channel_name).await;
     (
         remaining_users,
         was_relay,

--- a/src/signaling/handlers/utils.rs
+++ b/src/signaling/handlers/utils.rs
@@ -36,7 +36,7 @@ pub async fn update_existing_user(
     }
 }
 
-pub async fn remove_old_user_sessions(
+pub fn remove_old_user_sessions(
     channel: &mut Channel,
     user_name: &str,
     src_addr: SocketAddr,
@@ -78,7 +78,7 @@ pub async fn add_new_user(
     nat_kind: NatKind,
 ) -> (Channel, u32) {
     //Remove old user sessions with same name but different address
-    remove_old_user_sessions(channel, user_name, src_addr).await;
+    remove_old_user_sessions(channel, user_name, src_addr);
 
     let peer_id = channel.next_peer_id;
     channel.next_peer_id += 1;
@@ -93,7 +93,7 @@ pub async fn add_new_user(
     (channel.clone(), peer_id)
 }
 
-pub async fn find_and_remove_user(
+pub fn find_and_remove_user(
     channel: &mut Channel,
     user_name: &str,
     src_addr: SocketAddr,
@@ -118,7 +118,7 @@ pub async fn find_and_remove_user(
     }
 }
 
-pub async fn update_relay_after_departure(
+pub fn update_relay_after_departure(
     channel: &mut Channel,
     was_relay: bool,
 ) -> Option<SocketAddr> {
@@ -156,12 +156,12 @@ pub async fn handle_user_removal(
     if let Some(channels) = st.get_mut(server_id)
         && let Some(channel) = channels.get_mut(channel_name) {
             if let Some((found_was_relay, found_leaving_addr)) =
-                find_and_remove_user(channel, user_name, src_addr).await
+                find_and_remove_user(channel, user_name, src_addr)
             {
                 was_relay = found_was_relay;
                 leaving_user_addr = Some(found_leaving_addr);
 
-                lone_user_addr = update_relay_after_departure(channel, was_relay).await;
+                lone_user_addr = update_relay_after_departure(channel, was_relay);
 
                 println!("User {user_name} left {server_id}-{channel_name}");
             } else {

--- a/src/signaling/heartbeat.rs
+++ b/src/signaling/heartbeat.rs
@@ -226,7 +226,7 @@ async fn send_pings(socket: Arc<UdpSocket>, to_ping: Vec<SocketAddr>) {
 
 async fn send_notifications(socket: Arc<UdpSocket>, notify_msgs: Vec<(Vec<SocketAddr>, Vec<u8>)>) {
     //send notifications (USER_LEFT, MODE RELAY, MODE DIRECT messages}
-    for (peers_to_notify, payload) in cleanup_and_notify_iter(notify_msgs.into_iter()) {
+    for (peers_to_notify, payload) in cleanup_and_notify_iter(notify_msgs) {
         for addr in peers_to_notify {
             if let Err(e) = socket.send_to(&payload, addr).await {
                 eprintln!("Failed to send heartbeat notification to {addr}: {e}");

--- a/src/signaling/heartbeat.rs
+++ b/src/signaling/heartbeat.rs
@@ -97,8 +97,7 @@ fn handle_timed_out_user(
     notifications: &mut Vec<(Vec<SocketAddr>, Vec<u8>)>,
 ) {
     println!(
-        "User {} timed out from {}-{}",
-        user_name, server_id, channel_name
+        "User {user_name} timed out from {server_id}-{channel_name}"
     );
 
     let msg = format!("{MSG_USER_LEFT} {user_name} {user_addr}\n");
@@ -116,8 +115,7 @@ fn handle_timed_out_user(
     let was_relay = channel
         .relay
         .as_ref()
-        .map(|r| r == &user_name)
-        .unwrap_or(false);
+        .is_some_and(|r| r == user_name);
 
     channel.users.remove(user_index);
 
@@ -198,10 +196,10 @@ async fn collect_heartbeat_data(
     let mut notifications: Vec<(Vec<SocketAddr>, Vec<u8>)> = Vec::new();
 
     let server_ids: Vec<String> = st.keys().cloned().collect();
-    for sid in server_ids.iter() {
+    for sid in &server_ids {
         if let Some(channels) = st.get_mut(sid) {
             let channel_names: Vec<String> = channels.keys().cloned().collect();
-            for cname in channel_names.iter() {
+            for cname in &channel_names {
                 if let Some(channel) = channels.get_mut(cname) {
                     process_channel_heartbeat(
                         sid,
@@ -231,7 +229,7 @@ async fn send_notifications(socket: Arc<UdpSocket>, notify_msgs: Vec<(Vec<Socket
     for (peers_to_notify, payload) in cleanup_and_notify_iter(notify_msgs.into_iter()) {
         for addr in peers_to_notify {
             if let Err(e) = socket.send_to(&payload, addr).await {
-                eprintln!("Failed to send heartbeat notification to {}: {}", addr, e);
+                eprintln!("Failed to send heartbeat notification to {addr}: {e}");
             }
         }
     }
@@ -240,7 +238,7 @@ async fn send_notifications(socket: Arc<UdpSocket>, notify_msgs: Vec<(Vec<Socket
 async fn cleanup_empty_channels(state: Arc<Mutex<ServerMap>>, to_cleanup: Vec<(String, String)>) {
     if !to_cleanup.is_empty() {
         let mut st = state.lock().await;
-        for (sid, cname) in to_cleanup.into_iter() {
+        for (sid, cname) in to_cleanup {
             if let Some(chans) = st.get_mut(&sid) {
                 chans.remove(&cname);
                 if chans.is_empty() {

--- a/src/signaling/structures.rs
+++ b/src/signaling/structures.rs
@@ -19,7 +19,7 @@ pub struct User {
 }
 
 impl User {
-    pub fn new(user_name: &str, addr: SocketAddr, nat_kind: NatKind, peer_id: u32) -> Self {
+    #[must_use] pub fn new(user_name: &str, addr: SocketAddr, nat_kind: NatKind, peer_id: u32) -> Self {
         Self {
             peer_id,
             name: user_name.to_string(),

--- a/src/signaling/utils.rs
+++ b/src/signaling/utils.rs
@@ -10,6 +10,6 @@ where
     it.into_iter().collect()
 }
 
-pub fn generate_channel_id() -> u64 {
+#[must_use] pub fn generate_channel_id() -> u64 {
     OsRng.next_u64()
 }


### PR DESCRIPTION
This change adds pedanting clippy to the nat piercer. It is a "as-good-as-possible" linter for rust.
The code change in the first commit was done
automatically through clippy using:
```sh
cargo clippy --fix
```

The following commit fix the remaining issues...