### PR TITLE
A3(control): integrate websocket control client after welcome

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -15,6 +15,7 @@ use od_nat_piercer::{
         networking::*,
         structures::{NatKind, PeerInfo, PunchState, PunchSync, RelayState, RelaySync},
     },
+    control::client::start_control_client,
     proto::{
         control_text::{
             MSG_CONNECT, MSG_CONTROL, MSG_MODE, MSG_RELAY, MSG_SERVER_RELAY, NAT_TYPE_CONE,

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -11,11 +11,11 @@ use std::{
 
 use od_nat_piercer::{
     client::{
+        control_plane::start_control_client_after_welcome,
         handlers::*,
         networking::*,
         structures::{NatKind, PeerInfo, PunchState, PunchSync, RelayState, RelaySync},
     },
-    control::client::start_control_client,
     proto::{
         control_text::{
             MSG_CONNECT, MSG_CONTROL, MSG_MODE, MSG_RELAY, MSG_SERVER_RELAY, NAT_TYPE_CONE,
@@ -361,10 +361,26 @@ fn main_loop(
     send_via_server: &Arc<AtomicBool>,
     channel_id: &Arc<AtomicU64>,
     my_peer_id: &Arc<AtomicU32>,
+    signaling_ip: &str,
+    server_id: &str,
+    channel: &str,
 ) -> std::io::Result<()> {
     let mut buf = [0u8; 2048];
+    let mut control_client_started = false;
 
     println!("Starting main message loop...");
+
+    let pid = my_peer_id.load(Ordering::Acquire);
+
+    start_control_client_after_welcome(
+        &mut control_client_started,
+        signaling_ip,
+        server_id,
+        channel,
+        &user,
+        pid,
+    );
+
     loop {
         match socket.recv_from(&mut buf) {
             Ok((len, src)) => {
@@ -391,6 +407,17 @@ fn main_loop(
                         Kind::Dtls => println!("Got DTLS {} bytes from {}", payload.len(), src),
                         Kind::Srtp => println!("Got SRTP {} bytes from {}", payload.len(), src),
                     }
+                    let pid = my_peer_id.load(Ordering::Acquire);
+
+                    start_control_client_after_welcome(
+                        &mut control_client_started,
+                        signaling_ip,
+                        server_id,
+                        channel,
+                        &user,
+                        pid,
+                    );
+
                     continue;
                 }
 
@@ -565,5 +592,8 @@ fn main() -> std::io::Result<()> {
         &send_via_server,
         &channel_id,
         &my_peer_id,
+        &signaling_ip,
+        &server_id,
+        &channel,
     )
 }

--- a/src/client/control_plane.rs
+++ b/src/client/control_plane.rs
@@ -1,0 +1,30 @@
+use crate::control::client::start_control_client;
+
+pub fn start_control_client_after_welcome(
+    control_client_started: &mut bool,
+    signaling_ip: &str,
+    server_id: &str,
+    channel: &str,
+    user: &str,
+    peer_id: u32,
+) {
+    if *control_client_started {
+        return;
+    }
+
+    if peer_id == 0 {
+        return;
+    }
+
+    start_control_client(
+        signaling_ip.to_string(),
+        server_id.to_string(),
+        channel.to_string(),
+        user.to_string(),
+        peer_id,
+    );
+
+    *control_client_started = true;
+
+    println!("Started control WebSocket client with peer_id={}", peer_id);
+}

--- a/src/client/control_plane.rs
+++ b/src/client/control_plane.rs
@@ -1,5 +1,9 @@
 use crate::control::client::start_control_client;
 
+pub(crate) fn should_start_control_client(control_client_started: bool, peer_id: u32) -> bool {
+    !control_client_started && peer_id != 0
+}
+
 pub fn start_control_client_after_welcome(
     control_client_started: &mut bool,
     signaling_ip: &str,
@@ -8,11 +12,7 @@ pub fn start_control_client_after_welcome(
     user: &str,
     peer_id: u32,
 ) {
-    if *control_client_started {
-        return;
-    }
-
-    if peer_id == 0 {
+    if !should_start_control_client(*control_client_started, peer_id) {
         return;
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,3 +1,4 @@
+pub mod control_plane;
 pub mod handlers;
 pub mod networking;
 pub mod structures;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2,3 +2,6 @@ pub mod control_plane;
 pub mod handlers;
 pub mod networking;
 pub mod structures;
+
+#[cfg(test)]
+mod ut;

--- a/src/client/ut.rs
+++ b/src/client/ut.rs
@@ -1,0 +1,83 @@
+use crate::client::control_plane::should_start_control_client;
+use crate::client::handlers::try_handle_welcome;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_handle_welcome_sets_channel_id_and_peer_id() {
+        let channel_id = Arc::new(AtomicU64::new(0));
+        let my_peer_id = Arc::new(AtomicU32::new(0));
+
+        try_handle_welcome("WELCOME 123456789 42\n", &channel_id, &my_peer_id);
+
+        assert_eq!(channel_id.load(Ordering::Acquire), 123456789);
+        assert_eq!(my_peer_id.load(Ordering::Acquire), 42);
+    }
+
+    #[test]
+    fn try_handle_welcome_ignores_invalid_format() {
+        let channel_id = Arc::new(AtomicU64::new(0));
+        let my_peer_id = Arc::new(AtomicU32::new(0));
+
+        try_handle_welcome(
+            "WELCOME to cid:123456789 with pid:42\n",
+            &channel_id,
+            &my_peer_id,
+        );
+
+        assert_eq!(channel_id.load(Ordering::Acquire), 0);
+        assert_eq!(my_peer_id.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn try_handle_welcome_ignores_invalid_numeric_values() {
+        let channel_id = Arc::new(AtomicU64::new(0));
+        let my_peer_id = Arc::new(AtomicU32::new(0));
+
+        try_handle_welcome("WELCOME abc 42\n", &channel_id, &my_peer_id);
+
+        assert_eq!(channel_id.load(Ordering::Acquire), 0);
+        assert_eq!(my_peer_id.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn try_handle_welcome_ignores_invalid_peer_id() {
+        let channel_id = Arc::new(AtomicU64::new(0));
+        let my_peer_id = Arc::new(AtomicU32::new(0));
+
+        try_handle_welcome("WELCOME 123456789 abc\n", &channel_id, &my_peer_id);
+
+        assert_eq!(channel_id.load(Ordering::Acquire), 0);
+        assert_eq!(my_peer_id.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn try_handle_welcome_ignores_non_welcome_messages() {
+        let channel_id = Arc::new(AtomicU64::new(0));
+        let my_peer_id = Arc::new(AtomicU32::new(0));
+
+        try_handle_welcome("MODE RELAY\n", &channel_id, &my_peer_id);
+
+        assert_eq!(channel_id.load(Ordering::Acquire), 0);
+        assert_eq!(my_peer_id.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn should_start_control_client_when_not_started_and_peer_id_is_valid() {
+        assert!(should_start_control_client(false, 1));
+    }
+
+    #[test]
+    fn should_not_start_control_client_when_already_started() {
+        assert!(!should_start_control_client(true, 1));
+    }
+
+    #[test]
+    fn should_not_start_control_client_without_peer_id() {
+        assert!(!should_start_control_client(false, 0));
+    }
+}

--- a/src/control/client.rs
+++ b/src/control/client.rs
@@ -5,6 +5,8 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 use crate::control::messages::ControlMessage;
 
+const TEST_PAYLOAD_LEN: usize = 100 * 1024;
+
 pub fn start_control_client(
     signaling_ip: String,
     server_id: String,
@@ -56,7 +58,7 @@ async fn run_control_client(
     write.send(Message::Text(join_text)).await?;
     println!("Sent JoinControl on reliable control plane.");
 
-    let test_payload = "A".repeat(100 * 1024);
+    let test_payload = "A".repeat(TEST_PAYLOAD_LEN);
     let payload_len = test_payload.len();
 
     let control_msg = ControlMessage::ControlMsg {

--- a/src/control/client.rs
+++ b/src/control/client.rs
@@ -76,7 +76,6 @@ async fn run_control_client(
             match parsed {
                 ControlMessage::ControlAck { message_id } => {
                     println!("Received ControlAck for message_id={}", message_id);
-                    break;
                 }
                 other => {
                     println!("Received other control message: {:?}", other);

--- a/src/control/client.rs
+++ b/src/control/client.rs
@@ -1,0 +1,89 @@
+use std::thread;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+use crate::control::messages::ControlMessage;
+
+pub fn start_control_client(
+    signaling_ip: String,
+    server_id: String,
+    channel: String,
+    user: String,
+    peer_id: u32,
+) {
+    thread::spawn(move || {
+        let rt = match tokio::runtime::Runtime::new() {
+            Ok(rt) => rt,
+            Err(e) => {
+                eprintln!("Failed to create control client runtime: {}", e);
+                return;
+            }
+        };
+
+        rt.block_on(async move {
+            if let Err(e) =
+                run_control_client(signaling_ip, server_id, channel, user, peer_id).await
+            {
+                eprintln!("Control client error: {}", e);
+            }
+        });
+    });
+}
+
+async fn run_control_client(
+    signaling_ip: String,
+    server_id: String,
+    channel: String,
+    user: String,
+    peer_id: u32,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let ws_url = format!("ws://{}:2133", signaling_ip);
+
+    let (ws_stream, _) = connect_async(&ws_url).await?;
+    println!("Connected to control WebSocket server at {}", ws_url);
+
+    let (mut write, mut read) = ws_stream.split();
+
+    let join = ControlMessage::JoinControl {
+        server_id,
+        channel,
+        user,
+        peer_id,
+    };
+
+    let join_text = serde_json::to_string(&join)?;
+    write.send(Message::Text(join_text)).await?;
+    println!("Sent JoinControl on reliable control plane.");
+
+    let test_payload = "control-plane-test".to_string();
+
+    let control_msg = ControlMessage::ControlMsg {
+        message_id: 1,
+        payload: test_payload,
+    };
+
+    let msg_text = serde_json::to_string(&control_msg)?;
+    write.send(Message::Text(msg_text)).await?;
+    println!("Sent ControlMsg message_id=1");
+
+    while let Some(msg) = read.next().await {
+        let msg = msg?;
+
+        if let Message::Text(text) = msg {
+            let parsed: ControlMessage = serde_json::from_str(&text)?;
+
+            match parsed {
+                ControlMessage::ControlAck { message_id } => {
+                    println!("Received ControlAck for message_id={}", message_id);
+                    break;
+                }
+                other => {
+                    println!("Received other control message: {:?}", other);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/control/client.rs
+++ b/src/control/client.rs
@@ -56,7 +56,8 @@ async fn run_control_client(
     write.send(Message::Text(join_text)).await?;
     println!("Sent JoinControl on reliable control plane.");
 
-    let test_payload = "control-plane-test".to_string();
+    let test_payload = "A".repeat(100 * 1024);
+    let payload_len = test_payload.len();
 
     let control_msg = ControlMessage::ControlMsg {
         message_id: 1,
@@ -65,7 +66,7 @@ async fn run_control_client(
 
     let msg_text = serde_json::to_string(&control_msg)?;
     write.send(Message::Text(msg_text)).await?;
-    println!("Sent ControlMsg message_id=1");
+    println!("Sent ControlMsg message_id=1 payload_len={}", payload_len);
 
     while let Some(msg) = read.next().await {
         let msg = msg?;

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod messages;
 pub mod server;
 

--- a/src/control/server.rs
+++ b/src/control/server.rs
@@ -60,10 +60,16 @@ async fn handle_connection(
                 ControlMessage::JoinControl {
                     server_id,
                     channel,
-                    user: _,
-                    peer_id: _,
+                    user,
+                    peer_id,
                 } => {
                     let key = channel_key(&server_id, &channel);
+
+                    println!(
+                        "Control client joined: server_id={} channel={}, user={}, peer_id={}",
+                        server_id, channel, user, peer_id
+                    );
+
                     joined_channel = Some(key.clone());
 
                     let mut guard = peers.lock().await;
@@ -72,8 +78,13 @@ async fn handle_connection(
 
                 ControlMessage::ControlMsg {
                     message_id,
-                    payload: _,
+                    payload,
                 } => {
+                    println!(
+                        "Received ControlMsg message_id={} payload_len={}",
+                        message_id,
+                        payload.len(),
+                    );
                     let ack = ControlMessage::ControlAck { message_id };
                     let ack_text = serde_json::to_string(&ack)?;
                     let _ = tx.send(Message::Text(ack_text));

--- a/src/control/ut.rs
+++ b/src/control/ut.rs
@@ -90,4 +90,31 @@ mod tests {
             _ => panic!("expected ControlAck"),
         }
     }
+
+    #[test]
+    fn control_msg_large_payload_json_roundtrip() {
+        const PAYLOAD_LEN: usize = 100 * 1024;
+
+        let payload = "A".repeat(PAYLOAD_LEN);
+
+        let msg = ControlMessage::ControlMsg {
+            message_id: 1,
+            payload: payload.clone(),
+        };
+
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: ControlMessage = serde_json::from_str(&json).unwrap();
+
+        match parsed {
+            ControlMessage::ControlMsg {
+                message_id,
+                payload: parsed_payload,
+            } => {
+                assert_eq!(message_id, 1);
+                assert_eq!(parsed_payload.len(), PAYLOAD_LEN);
+                assert_eq!(parsed_payload, payload);
+            }
+            _ => panic!("expected ControlMsg"),
+        }
+    }
 }

--- a/src/signaling/handlers/connect.rs
+++ b/src/signaling/handlers/connect.rs
@@ -16,10 +16,12 @@ use super::{
 };
 
 async fn send_welcome(socket: &Arc<UdpSocket>, dst: SocketAddr, channel_id: u64, peer_id: u32) {
-    let payload = format!("{MSG_WELCOME} to cid:{channel_id} with pid:{peer_id}\n");
+    let payload = format!("{MSG_WELCOME} {channel_id} {peer_id}\n");
     let hdr = Header::welcome(channel_id, peer_id, payload.len() as u16);
-
     let pkt = packet::encode(hdr, payload.as_bytes());
+
+    println!("Sending WELCOME to {dst}: channel_id={channel_id}, peer_id={peer_id}");
+
     let _ = socket.send_to(&pkt, dst).await;
 }
 

--- a/src/signaling/handlers/connect.rs
+++ b/src/signaling/handlers/connect.rs
@@ -15,8 +15,12 @@ use super::{
     utils::{add_new_user, remove_user_from_other_channels, update_existing_user},
 };
 
+fn welcome_payload(channel_id: u64, peer_id: u32) -> String {
+    format!("{MSG_WELCOME} {channel_id} {peer_id}\n")
+}
+
 async fn send_welcome(socket: &Arc<UdpSocket>, dst: SocketAddr, channel_id: u64, peer_id: u32) {
-    let payload = format!("{MSG_WELCOME} {channel_id} {peer_id}\n");
+    let payload = welcome_payload(channel_id, peer_id);
     let hdr = Header::welcome(channel_id, peer_id, payload.len() as u16);
     let pkt = packet::encode(hdr, payload.as_bytes());
 
@@ -89,4 +93,11 @@ pub async fn handle_connect_message(
         state,
     )
     .await;
+}
+
+#[test]
+fn welcome_payload_uses_machine_readable_format() {
+    let payload = welcome_payload(123456789, 42);
+
+    assert_eq!(payload, "WELCOME 123456789 42\n");
 }


### PR DESCRIPTION
This PR continues A3 by integrating the client-side reliable control plane over WebSocket.

The signaling server already exposes a dedicated WebSocket control server on port ```2133```. This PR updates the client flow so that, after receiving a valid ```WELCOME``` message and obtaining its assigned ```peer_id```, the client starts a WebSocket control connection and joins the reliable control plane.

## What was implemented
- Start the WebSocket control client after ```WELCOME``` is received and parsed
- Add client-side control plane startup logic based on ```peer_id``` availability
- Add a dedicated client control-plane integration helper
- Send ```JoinControl``` over the WebSocket connection
- Send a large test ```ControlMsg``` over the reliable control plane
- Receive ```ControlAck``` from the server
- Keep the WebSocket control connection alive after receiving ACK
- Add logging for control payload sizes on both client and server
- Fix ```WELCOME``` payload format so it is machine-readable by the client (from temporary human-readable format to ```WELCOME <channel_id> <peer_id>```

## Verified behavior
Tested locally with one signaling server and one client.

The following flow is now working:
```
UDP CONNECT
-> UDP WELCOME
-> client parses channel_id and peer_id
-> client starts WebSocket control client
-> client sends JoinControl
-> client sends 100KB ControlMsg
-> server receives ControlMsgs
-> server sends ControlAck
-> client receives ControlAck
```

## Temporary code / future cleanup
The following parts are intentionally temporary and will be removed or replaced in future work:
- The client currently sends a hardcoded test ```ControlMsg``` automatically after joining the WebSocket control plane
- The test payload is currently hardcoded as a 100KB string
- ```message_id=1``` is hardcoded for the current ACK proof-of-concept
- Payload length logs are mainly debug/validation logs and will be reduced or moved behind structured logging later
- The current control message is only a transport validation message, not an MLS message yet
- Real pending-message tracking, timeout handling, retry logic, and server-side broadcast are not implemented yet

## Next steps
- Add pendind ACK tracking on the client
- Add timeout + retry for reliable control messages
- Add server-side broadcast to all WebSocket control clients in the same channel
- Replace the temporary test ```ControlMsg``` with real MLS/control-plane messages